### PR TITLE
Virtual Hosts: support HTTP/2 using :authority

### DIFF
--- a/src/virtual_hosts.rs
+++ b/src/virtual_hosts.rs
@@ -17,20 +17,37 @@ pub(crate) fn get_real_root<'a, T>(
     req: &mut Request<T>,
     vhosts_opts: Option<&'a [VirtualHosts]>,
 ) -> Option<&'a PathBuf> {
-    if let Some(vhosts) = vhosts_opts {
-        if let Ok(host_str) = req.headers().get(HOST)?.to_str() {
-            for vhost in vhosts {
-                if vhost.host == host_str {
-                    tracing::info!(
-                        "virtual host matched: vhost={} vhost_root={} method={} uri={}",
-                        vhost.host,
-                        vhost.root.display(),
-                        req.method(),
-                        req.uri(),
-                    );
-                    return Some(&vhost.root);
-                }
-            }
+    let vhosts = vhosts_opts?;
+
+    let request_host_str = if let Some(authority) = req.uri().authority() {
+        // HTTP2
+        authority.host()
+    } else {
+        // HTTP1 - fall back to host header
+        let host_header = req.headers().get(HOST)?.to_str().ok()?;
+
+        // host header can include the port -> remove it
+        host_header
+            .rsplit_once(":")
+            .and_then(|(potential_host, potential_port)| {
+                potential_port
+                    .parse::<u16>()
+                    .is_ok()
+                    .then_some(potential_host)
+            })
+            .unwrap_or(host_header)
+    };
+
+    for vhost in vhosts {
+        if vhost.host == request_host_str {
+            tracing::info!(
+                "virtual host matched: vhost={} vhost_root={} method={} uri={}",
+                vhost.host,
+                vhost.root.display(),
+                req.method(),
+                req.uri(),
+            );
+            return Some(&vhost.root);
         }
     }
     None


### PR DESCRIPTION
It resolves #569 and supersedes the previous one #570 by @CrazyCraftix accidentally closed.

## Description
So far, the HTTP host header has been used to determine the hostname that is being accessed. In HTTP/2, this header is not guaranteed to be sent. Instead, the ":authority" pseudo-header field is used. I added a check for that header to make virtual hosts also work with HTTP/2.

Also I found out that the HTTP host header may also contain the port number, so I added a check to remove it if it's there.

## How Has This Been Tested?
~Not thoroughly, just manually for my usecase, so there may still be problems I didn't consider.~
~I suppose an automated test would be nice but I'm not sure what's the best way to do this.~

See unit tests added.