### PR TITLE
Add `exit_on_error` option for `Server::run_server_on_rt`

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -115,7 +115,7 @@ impl Server {
     /// Build and run the multi-threaded `Server` on the Tokio runtime.
     ///
     /// Setting `exit_on_error` to `true` will exit the entire process if
-    /// the server fails to start.
+    /// the server fails to start (previous behaviour).
     pub fn run_server_on_rt<F>(self, cancel_recv: Option<Receiver<()>>, cancel_fn: F, exit_on_error: bool) -> Result
     where
         F: FnOnce(),

--- a/src/server.rs
+++ b/src/server.rs
@@ -116,7 +116,12 @@ impl Server {
     ///
     /// Setting `exit_on_error` to `true` will exit the entire process if
     /// the server fails to start (previous behaviour).
-    pub fn run_server_on_rt<F>(self, cancel_recv: Option<Receiver<()>>, cancel_fn: F, exit_on_error: bool) -> Result
+    pub fn run_server_on_rt<F>(
+        self,
+        cancel_recv: Option<Receiver<()>>,
+        cancel_fn: F,
+        exit_on_error: bool,
+    ) -> Result
     where
         F: FnOnce(),
     {

--- a/src/server.rs
+++ b/src/server.rs
@@ -93,7 +93,7 @@ impl Server {
     ///
     /// [`cancel`]: <https://docs.rs/tokio/latest/tokio/sync/watch/struct.Receiver.html>
     pub fn run_standalone(self, cancel: Option<Receiver<()>>) -> Result {
-        self.run_server_on_rt(cancel, || {})
+        self.run_server_on_rt(cancel, || {}, true)
     }
 
     /// Run the multi-threaded `Server` which will be used by a Windows service.
@@ -109,31 +109,38 @@ impl Server {
     where
         F: FnOnce(),
     {
-        self.run_server_on_rt(cancel, cancel_fn)
+        self.run_server_on_rt(cancel, cancel_fn, true)
     }
 
     /// Build and run the multi-threaded `Server` on the Tokio runtime.
-    pub fn run_server_on_rt<F>(self, cancel_recv: Option<Receiver<()>>, cancel_fn: F) -> Result
+    ///
+    /// Setting `exit_on_error` to `true` will exit the entire process if
+    /// the server fails to start.
+    pub fn run_server_on_rt<F>(self, cancel_recv: Option<Receiver<()>>, cancel_fn: F, exit_on_error: bool) -> Result
     where
         F: FnOnce(),
     {
         tracing::debug!(%self.worker_threads, "initializing tokio runtime with multi-threaded scheduler");
 
-        tokio::runtime::Builder::new_multi_thread()
+        let rt = tokio::runtime::Builder::new_multi_thread()
             .worker_threads(self.worker_threads)
             .max_blocking_threads(self.max_blocking_threads)
             .thread_name("static-web-server")
             .enable_all()
-            .build()?
-            .block_on(async {
-                tracing::trace!("tokio runtime initialized");
-                if let Err(err) = self.start_server(cancel_recv, cancel_fn).await {
-                    tracing::error!("server failed to start up: {:?}", err);
-                    std::process::exit(1)
-                }
-            });
+            .build()?;
 
-        Ok(())
+        let res = rt.block_on(async {
+            tracing::trace!("tokio runtime initialized");
+            self.start_server(cancel_recv, cancel_fn).await
+        });
+
+        if let Err(err) = &res {
+            tracing::error!("server failed to start up: {:?}", err);
+            if exit_on_error {
+                std::process::exit(1)
+            }
+        }
+        res
     }
 
     /// Run the inner Hyper `HyperServer` (HTTP1/HTTP2) forever on the current thread


### PR DESCRIPTION
add `exit_on_error` option when starting server to choose if the entire process exits if the server fails to start

<!--- Provide a general summary of your changes in the Title above -->
<!--- Read the docs/PULL_REQUESTS.md -->

## Description
<!--- Describe your changes but try to be as concise as possible -->

Added `exit_on_error` as an additional argument to `run_server_on_rt`. When set to `true` this exits the entire process if the server fails to start (the current behavior). When set to false the error is propagated to the caller of `run_server_on_rt`. `run_standalone` and `run_as_service` don't expose this parameter, passing `true` to keep the current behavior.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

I'm using `static-web-server` as a library and found it killed my entire program when it failed to start, but I need a more graceful exit (clean up, etc).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- See how your change affects other areas of the code, etc. -->

I ran `cargo test` and all tests passed. This was on Linux.

## Screenshots (if appropriate):
