### PR TITLE
Drop `lazy_static` dependency for fixed text mime types list in compression module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2147,7 +2147,6 @@ dependencies = [
  "http",
  "http-serde",
  "hyper",
- "lazy_static",
  "listenfd",
  "maud",
  "mime_guess",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,6 @@ headers = "0.3"
 http = "0.2"
 http-serde = "1.1"
 hyper = { version = "0.14", features = ["stream", "http1", "http2", "tcp", "server"] }
-lazy_static = "1.5"
 listenfd = "1.0"
 maud = { version = "0.27" }
 mime_guess = "2.0"

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -24,10 +24,8 @@ use hyper::{
     Body, Method, Request, Response, StatusCode,
     header::{CONTENT_ENCODING, CONTENT_LENGTH},
 };
-use lazy_static::lazy_static;
 use mime_guess::{Mime, mime};
 use pin_project::pin_project;
-use std::collections::HashSet;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 use tokio_util::io::{ReaderStream, StreamReader};
@@ -40,19 +38,17 @@ use crate::{
     settings::CompressionLevel,
 };
 
-lazy_static! {
-    /// Contains a fixed list of common text-based MIME types that aren't recognizable in a generic way.
-    static ref TEXT_MIME_TYPES: HashSet<&'static str> = [
-        "application/rtf",
-        "application/javascript",
-        "application/json",
-        "application/xml",
-        "font/ttf",
-        "application/font-sfnt",
-        "application/vnd.ms-fontobject",
-        "application/wasm",
-    ].into_iter().collect();
-}
+/// Contains a fixed list of common text-based MIME types that aren't recognizable in a generic way.
+const TEXT_MIME_TYPES: [&str; 8] = [
+    "application/rtf",
+    "application/javascript",
+    "application/json",
+    "application/xml",
+    "font/ttf",
+    "application/font-sfnt",
+    "application/vnd.ms-fontobject",
+    "application/wasm",
+];
 
 /// List of encodings that can be handled given enabled features.
 const AVAILABLE_ENCODINGS: &[ContentCoding] = &[
@@ -197,7 +193,7 @@ fn is_text(mime: Mime) -> bool {
         || mime
             .suffix()
             .is_some_and(|suffix| suffix == mime::XML || suffix == mime::JSON)
-        || TEXT_MIME_TYPES.contains(mime.essence_str())
+        || TEXT_MIME_TYPES.contains(&mime.essence_str())
 }
 
 /// Create a wrapping handler that compresses the Body of a [`Response`].


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Read the docs/PULL_REQUESTS.md -->

## Description
<!--- Describe your changes but try to be as concise as possible -->

This PR removes `lazy_static` dependency in favor of a fixed text-mime type list in the _compression_ module.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- See how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
