### PR TITLE
Replace `regex` crate with `regex-lite` to reduce binary size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1768,18 +1768,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex"
-version = "1.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
 name = "regex-automata"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1789,6 +1777,12 @@ dependencies = [
  "memchr",
  "regex-syntax",
 ]
+
+[[package]]
+name = "regex-lite"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d942b98df5e658f56f20d592c7f868833fe38115e65c33003d8cd224b0155da"
 
 [[package]]
 name = "regex-syntax"
@@ -2154,7 +2148,7 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "prometheus",
- "regex",
+ "regex-lite",
  "rustls-pemfile",
  "serde",
  "serde_ignored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,7 +85,7 @@ mime_guess = "2.0"
 mini-moka = { version = "0.10.3", optional = true }
 percent-encoding = "2.3"
 pin-project = "1.1"
-regex = "1.12.2"
+regex-lite = "0.1.8"
 rustls-pemfile = { version = "2.2", optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_ignored = "0.1"

--- a/src/redirects.rs
+++ b/src/redirects.rs
@@ -8,7 +8,7 @@
 
 use headers::HeaderValue;
 use hyper::{Body, Request, Response, StatusCode};
-use regex::Regex;
+use regex_lite::Regex;
 
 use crate::{Error, error_page, handler::RequestHandlerOpts, settings::Redirects};
 
@@ -147,7 +147,7 @@ mod tests {
         settings::{Advanced, Redirects},
     };
     use hyper::{Body, Request, Response, StatusCode};
-    use regex::Regex;
+    use regex_lite::Regex;
 
     fn make_request(host: &str, uri: &str) -> Request<Body> {
         let mut builder = Request::builder();

--- a/src/rewrites.rs
+++ b/src/rewrites.rs
@@ -126,7 +126,7 @@ mod tests {
         settings::{Advanced, Rewrites, file::RedirectsKind},
     };
     use hyper::{Body, Request, Response, StatusCode, header::HOST};
-    use regex::Regex;
+    use regex_lite::Regex;
 
     fn make_request(host: &str, uri: &str) -> Request<Body> {
         let mut builder = Request::builder();

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -10,7 +10,7 @@ use clap::Parser;
 use globset::{Glob, GlobBuilder, GlobMatcher};
 use headers::HeaderMap;
 use hyper::StatusCode;
-use regex::Regex;
+use regex_lite::Regex;
 use std::path::{Path, PathBuf};
 
 use crate::{Context, Result, helpers, logger};


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->
<!--- Read the docs/PULL_REQUESTS.md -->

## Description
<!--- Describe your changes but try to be as concise as possible -->

This PR optimizes for binary size by replacing the `regex` crate with its lightweight equivalent ([regex-lite](https://crates.io/crates/regex-lite)).
The change reports a binary size reduction of approximately `~500KB`.

**x86_64-unknown-linux-musl example:**

before (v2.39.0):

```
8,9M	static-web-server
```

after:

```
8,4M    static-web-server
```

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- See how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
