### PR TITLE
Move perfcheck CI workflow behind comment trigger

### DIFF
--- a/.github/workflows/perfcheck.yml
+++ b/.github/workflows/perfcheck.yml
@@ -1,19 +1,7 @@
 name: perfcheck
 on:
-  # merge_group:
-  #   branches:
-  #     - master
-  pull_request:
-    paths:
-      - .github/workflows/perfcheck.yml
-      - .cargo/config.toml
-      - scripts/ci/vegeta_report_to_csv.jq
-      - Cargo.lock
-      - Cargo.toml
-      - src/**
-  push:
-    branches:
-    - master
+  issue_comment:
+    types: [created, edited]
     paths:
       - .github/workflows/perfcheck.yml
       - .cargo/config.toml
@@ -24,8 +12,10 @@ on:
 
 jobs:
   benchmark:
+    if: github.event.issue.pull_request && contains(github.event.comment.body, '/try+ perfcheck')
     name: benchmark
     runs-on: ubuntu-22.04
+    continue-on-error: true
     env:
       # Cargo binary
       CARGO_BIN: cargo
@@ -45,6 +35,7 @@ jobs:
       CADDY_VERSION: "2.7.6"
 
     strategy:
+      fail-fast: false
       matrix:
         include:
         - title: "Small file (dynamic compression)"
@@ -219,9 +210,11 @@ jobs:
           overview.png
 
   merge-artifacts:
+    if: github.event.issue.pull_request && contains(github.event.comment.body, '/try+ perfcheck')
     name: merge-artifacts
     needs: benchmark
     runs-on: ubuntu-22.04
+    continue-on-error: true
 
     steps:
     - name: Merge benchmark plots


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Read the docs/PULL_REQUESTS.md -->

## Description
<!--- Describe your changes but try to be as concise as possible -->

This PR temporarily moves the `perfcheck` CI workflow behind the PR comment trigger due to CI issues and delays.

We will find a better place for it in the future. 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

```sh
Run dtolnay/rust-toolchain@stable
Run : parse toolchain version
Run : construct rustup command line
Run : set $CARGO_HOME
Run : install rustup if needed
info: downloading installer
warn: It looks like you have an existing rustup settings file at:
warn: /home/runner/.rustup/settings.toml
warn: Rustup will install the default toolchain as specified in the settings file,
warn: instead of the one inferred from the default host triple.
error: could not copy file from '/tmp/tmp.1qVxbnYTKJ/rustup-init' to '/home/runner/.cargo/bin/rustup': No such file or directory (os error 2)
Error: Process completed with exit code 1.
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- See how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
