### PR TITLE
Add `armv7-unknown-linux-gnueabihf` target

### DIFF
--- a/.github/workflows/devel.yml
+++ b/.github/workflows/devel.yml
@@ -56,6 +56,7 @@ jobs:
           - linux-arm-gnueabihf
           - linux-musl-armv6
           - linux-musl-armv7
+          - linux-gnu-armv7
           - linux-ppc64le
           - linux-s390x
           # NOTE: looks like not supported by `listenfd` crate
@@ -113,6 +114,10 @@ jobs:
             os: ubuntu-22.04
             rust: stable
             target: armv7-unknown-linux-musleabihf
+          - build: linux-gnu-armv7
+            os: ubuntu-22.04
+            rust: stable
+            target: armv7-unknown-linux-gnueabihf
           - build: linux-ppc64le
             os: ubuntu-22.04
             rust: stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,7 @@ jobs:
           - linux-arm-gnueabihf
           - linux-musl-armv6
           - linux-musl-armv7
+          - linux-gnu-armv7
           - linux-ppc64le
           - linux-s390x
           # - linux-android-armv7
@@ -108,6 +109,10 @@ jobs:
           os: ubuntu-22.04
           rust: stable
           target: armv7-unknown-linux-musleabihf
+        - build: linux-gnu-armv7
+          os: ubuntu-22.04
+          rust: stable
+          target: armv7-unknown-linux-gnueabihf
         - build: linux-ppc64le
           os: ubuntu-22.04
           rust: stable

--- a/docs/content/download-and-install.template.md
+++ b/docs/content/download-and-install.template.md
@@ -166,6 +166,8 @@ Pre-compiled binaries grouped by CPU architectures.
 <small>**SHA256SUM:** `{{arm-unknown-linux-musleabihf.tar.gz}}`</small>
 - [static-web-server-{{RELEASE_VERSION}}-armv7-unknown-linux-musleabihf.tar.gz](https://github.com/static-web-server/static-web-server/releases/download/{{RELEASE_VERSION}}/static-web-server-{{RELEASE_VERSION}}-armv7-unknown-linux-musleabihf.tar.gz)<br>
 <small>**SHA256SUM:** `{{armv7-unknown-linux-musleabihf.tar.gz}}`</small>
+- [static-web-server-{{RELEASE_VERSION}}-armv7-unknown-linux-gnueabihf.tar.gz](https://github.com/static-web-server/static-web-server/releases/download/{{RELEASE_VERSION}}/static-web-server-{{RELEASE_VERSION}}-armv7-unknown-linux-gnueabihf.tar.gz)<br>
+<small>**SHA256SUM:** `{{armv7-unknown-linux-gnueabihf.tar.gz}}`</small>
 
 ### PowerPC
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Read the docs/PULL_REQUESTS.md -->

## Description
<!--- Describe your changes but try to be as concise as possible -->

This PR introduces a new binary target [`armv7-unknown-linux-gnueabihf`](https://doc.rust-lang.org/beta/rustc/platform-support/armv7-unknown-linux-gnueabi.html).

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- See how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
