### PR TITLE
Drop `jemalloc` in favor of `mimalloc` allocator for MUSL targets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1361,6 +1361,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "667f4fec20f29dfc6bc7357c582d91796c169ad7e2fce709468aefeb2c099870"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1451,6 +1461,15 @@ name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+
+[[package]]
+name = "mimalloc"
+version = "0.1.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1ee66a4b64c74f4ef288bcbb9192ad9c3feaad75193129ac8509af543894fd8"
+dependencies = [
+ "libmimalloc-sys",
+]
 
 [[package]]
 name = "mime"
@@ -2138,6 +2157,7 @@ dependencies = [
  "hyper",
  "listenfd",
  "maud",
+ "mimalloc",
  "mime_guess",
  "mini-moka",
  "percent-encoding",
@@ -2152,7 +2172,6 @@ dependencies = [
  "shadow-rs",
  "signal-hook",
  "signal-hook-tokio",
- "tikv-jemallocator",
  "tokio",
  "tokio-metrics-collector",
  "tokio-rustls",
@@ -2269,26 +2288,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "tikv-jemalloc-sys"
-version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
-name = "tikv-jemallocator"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0359b4327f954e0567e69fb191cf1436617748813819c94b8cd4a431422d053a"
-dependencies = [
- "libc",
- "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,8 +99,8 @@ toml = "0.9"
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 tracing-subscriber = { version = "0.3", default-features = false, features = ["smallvec", "registry", "parking_lot", "fmt", "ansi", "tracing-log"] }
 
-[target.'cfg(all(target_env = "musl", target_pointer_width = "64"))'.dependencies.tikv-jemallocator]
-version = "0.6"
+[target.'cfg(all(target_env = "musl", target_pointer_width = "64"))'.dependencies.mimalloc]
+version = "0.1.48"
 
 [target.'cfg(unix)'.dependencies]
 signal-hook = { version = "0.3", features = ["extended-siginfo"] }
@@ -142,10 +142,3 @@ pre-build = [
     "cp /tmp/netbsd/usr/lib/libexecinfo.so /usr/local/x86_64-unknown-netbsd/lib",
     "rm -rf base.tar.xz /tmp/netbsd",
 ]
-
-# Cross: Linux ARM64 Musl only
-[package.metadata.cross.target.aarch64-unknown-linux-musl.env]
-# workaround for jemalloc on ARM64 (musl) by using 64KB pagesize by default (max value)
-# - https://github.com/static-web-server/static-web-server/issues/440
-# - https://github.com/jemalloc/jemalloc/issues/467
-passthrough = ["JEMALLOC_SYS_WITH_LG_PAGE=16"]

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -10,7 +10,7 @@
 
 #[cfg(all(target_env = "musl", target_pointer_width = "64"))]
 #[global_allocator]
-static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 use static_web_server::{
     Result, Settings,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Read the docs/PULL_REQUESTS.md -->

## Description
<!--- Describe your changes but try to be as concise as possible -->

This PR drops [jemalloc](https://github.com/jemalloc/jemalloc) (now archived) in favor of [mimalloc](https://github.com/microsoft/mimalloc) allocator for MUSL targets (statically-linked binaries).
The change brings performance improvements and significant memory savings.

**Generic benchmark tests**

In the tests below, using `mimalloc` decreases `~68%` RAM usage. But remember that this test is generic and could vary.

- Intel Core i7 8GB
- Linux 6.7.9-arch1-1
- Rust 1.76.0

**jemalloc** (`~32MB` RAM)

```sh
$ wrk -c500 -t12 -d5s --latency http://localhost:8787
Running 5s test @ http://localhost:8787
  12 threads and 500 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    11.59ms   13.03ms 219.98ms   96.61%
    Req/Sec     3.54k     0.89k    7.59k    84.24%
  Latency Distribution
     50%    9.89ms
     75%   13.56ms
     90%   18.12ms
     99%   36.89ms
  208531 requests in 5.03s, 171.43MB read
Requests/sec:  41447.05
Transfer/sec:     34.07MB
```

**mimalloc** (`~22MB` RAM)

```sh
$ wrk -c500 -t12 -d5s --latency http://localhost:8787
Running 5s test @ http://localhost:8787
  12 threads and 500 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    11.15ms    5.34ms  51.04ms   73.07%
    Req/Sec     3.58k   753.06    10.94k    85.52%
  Latency Distribution
     50%   10.53ms
     75%   13.80ms
     90%   18.04ms
     99%   27.32ms
  212102 requests in 5.10s, 174.36MB read
Requests/sec:  41578.55
Transfer/sec:     34.18MB
```

**Docker containers**

The result using the latest `joseluisq/static-web-server:2-alpine` (jemalloc, `~30MB` RAM) and a custom Alpine image (mimalloc `~22MB` RAM) is a bit similar.

**Targets affected**

- `x86_64-unknown-linux-musl`
- `i686-unknown-linux-musl`
- `aarch64-unknown-linux-musl`
- `arm-unknown-linux-musleabihf`
- `armv7-unknown-linux-musleabihf`

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- See how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
