### PR TITLE
docs: add missing newline to ensure that bulleted list is rendered correctly

### DIFF
--- a/docs/content/features/markdown-content-negotiation.md
+++ b/docs/content/features/markdown-content-negotiation.md
@@ -71,6 +71,7 @@ curl -H "Accept: text/markdown" https://example.com/docs/
 ```
 
 This approach is superior to traditional `.md` URL suffixes because:
+
 - Uses standard HTTP content negotiation
 - Same URL serves both HTML (browsers) and Markdown (LLMs)
 - No need for separate URL structures or redirects


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Read the docs/PULL_REQUESTS.md -->

## Description

I was going through the changelog of the latest version and noticed an incorrectly rendered list in https://static-web-server.net/features/markdown-content-negotiation/#llm-friendly-content-with-llmstxt at the end of that section:

> This approach is superior to traditional .md URL suffixes because: - Uses standard HTTP content negotiation - Same URL serves both HTML (browsers) and Markdown (LLMs) - No need for separate URL structures or redirects - Follows REST principles for resource representation

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

Note that it would be possible to catch (and fix) this automatically via `mdformat` with the `mdformat-mkdocs` plugin. I use it as a pre-commit hook but could also be added to CI only.

Let me know if this is something you would find useful and I could contribute a PR.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- See how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
