### PR TITLE
Prevent hidden root path to be ignored by `--ignore-hidden-files` feature

### DIFF
--- a/src/static_files.rs
+++ b/src/static_files.rs
@@ -180,7 +180,7 @@ pub async fn handle(opts: &HandleOpts<'_>) -> Result<StaticFileResponse, StatusC
     )?;
 
     // Check for a hidden file/directory (dotfile) and ignore it if feature enabled
-    if opts.ignore_hidden_files && file_path.is_hidden() {
+    if opts.ignore_hidden_files && file_path.strip_prefix(opts.base_path).unwrap().is_hidden() {
         return Err(StatusCode::NOT_FOUND);
     }
 

--- a/src/static_files.rs
+++ b/src/static_files.rs
@@ -181,6 +181,10 @@ pub async fn handle(opts: &HandleOpts<'_>) -> Result<StaticFileResponse, StatusC
 
     // Check for a hidden file/directory (dotfile) and ignore it if feature enabled
     if opts.ignore_hidden_files && file_path.strip_prefix(opts.base_path).unwrap().is_hidden() {
+        tracing::trace!(
+            "considering hidden file {} as not found",
+            file_path.display()
+        );
         return Err(StatusCode::NOT_FOUND);
     }
 

--- a/tests/fixtures/.hidden-root/foo.html
+++ b/tests/fixtures/.hidden-root/foo.html
@@ -1,0 +1,1 @@
+<h1>Just an HTML file</h1>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Read the docs/PULL_REQUESTS.md -->

## Description
<!--- Describe your changes but try to be as concise as possible -->

This PR fixes an issue where SWS returned 404 when serving from a hidden directory (i.e., `/.root`) together with the `--ignore-hidden-files` feature being enabled.

**Server configuration**

```sh
$ static-web-server -p 8788 -d .public/ --ignore-hidden-files
```

**Before**

```sh
$ curl -I http://localhost:8788
# HTTP/1.1 404 Not Found
# content-type: text/html; charset=utf-8
# content-length: 312
# accept-ranges: bytes
# vary: accept-encoding
# cache-control: max-age=86400
# date: Fri, 26 Dec 2025 14:24:54 GMT
```

**After (expected)**

```sh
$ curl -I http://localhost:8788
# HTTP/1.1 200 OK
# content-length: 639
# content-type: text/html
# accept-ranges: bytes
# last-modified: Sat, 20 Dec 2025 11:48:14 GMT
# vary: accept-encoding
# cache-control: max-age=86400
# date: Fri, 26 Dec 2025 14:27:05 GMT
```

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

I think that only components of the path _under_ the base path should be considered for being hidden.
The base path is explicit and there is no point in considering its components.
Current behavior was undesirable when I was trying to make automated tests that make use of this project.
In my tests, I have created temporary base directories that happen to have a hidden component.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- See how your change affects other areas of the code, etc. -->

Added a test.

## Screenshots (if appropriate):
