### PR TITLE
Prefer 'gnueabihf' binary for Debian `linux/arm/v7` Docker image

### DIFF
--- a/docker/debian/Dockerfile
+++ b/docker/debian/Dockerfile
@@ -18,9 +18,7 @@ RUN set -ex \
         "linux/amd64") target='x86_64-unknown-linux-gnu' ;; \
         "linux/arm64") target='aarch64-unknown-linux-gnu' ;; \
         "linux/386") target='i686-unknown-linux-gnu' ;; \
-        # TODO: linux/arm/v7 will use 'gnueabihf' instead of 'musleabihf' binary once available \
-        # "linux/arm/v7") target='armv7-unknown-linux-gnueabihf' ;; \
-        "linux/arm/v7") target='armv7-unknown-linux-musleabihf' ;; \
+        "linux/arm/v7") target='armv7-unknown-linux-gnueabihf' ;; \
         "linux/arm/v6") target='arm-unknown-linux-gnueabihf' ;; \
         "linux/ppc64le") target='powerpc64le-unknown-linux-gnu' ;; \
         "linux/s390x") target='s390x-unknown-linux-gnu' ;; \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Read the docs/PULL_REQUESTS.md -->

## Description
<!--- Describe your changes but try to be as concise as possible -->

This PR makes use of the 'gnueabihf' binary instead of the 'musleabihf' one after https://github.com/static-web-server/static-web-server/pull/586 for the Debian-based Docker `linux/arm/v7` image.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- See how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
