### PR TITLE
Replace unmaintained `rustls-pemfile` dependency in TLS module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1853,19 +1853,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
 name = "rustls-pki-types"
-version = "1.13.1"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "708c0f9d5f54ba0272468c1d306a52c495b31fa155e91bc25371e6df7996908c"
+checksum = "21e6f2ab2928ca4291b86736a8bd920a277a399bba1589409d72154ff87c1282"
 dependencies = [
  "zeroize",
 ]
@@ -2164,7 +2155,7 @@ dependencies = [
  "pin-project",
  "prometheus",
  "regex-lite",
- "rustls-pemfile",
+ "rustls-pki-types",
  "serde",
  "serde_ignored",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ default = ["compression", "http2", "directory-listing", "directory-listing-downl
 # Include all features (used when building SWS binaries)
 all = ["default", "experimental"]
 # HTTP2
-http2 = ["tokio-rustls", "rustls-pemfile"]
+http2 = ["tokio-rustls", "rustls-pki-types"]
 # Compression
 compression = ["compression-brotli", "compression-deflate", "compression-gzip", "compression-zstd"]
 compression-brotli = ["async-compression/brotli"]
@@ -86,7 +86,7 @@ mini-moka = { version = "0.10.3", optional = true }
 percent-encoding = "2.3"
 pin-project = "1.1"
 regex-lite = "0.1.8"
-rustls-pemfile = { version = "2.2", optional = true }
+rustls-pki-types = { version = "1.13.2", optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_ignored = "0.1"
 serde_json = "1.0"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Read the docs/PULL_REQUESTS.md -->

## Description
<!--- Describe your changes but try to be as concise as possible -->

This PR replaces the unmaintained `rustls-pemfile` (https://github.com/rustls/pemfile/issues/61) by `rustls-pki-types` crate.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

It resolves #598.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- See how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
