### PR TITLE
Enable `--ignore-hidden-files` and `--disable-symlinks` options by default

### DIFF
--- a/docs/content/features/disable-symlinks.md
+++ b/docs/content/features/disable-symlinks.md
@@ -1,16 +1,16 @@
 # Disable Symlinks
 
-**`SWS`** does follow symlinks by default. However, it's possible to disable all symlinks (deny access) by preventing to following files or directories if any path name component is a symbolic link. This applies to direct requests (URL) or those using the directory listing.
+**`SWS`** *does not* follow symlinks by default for security reasons.
 
-As a result, SWS will respond with a `403 Forbidden` status if a symlink is requested or it won't be shown in the directory listing if enabled.
+As a result, SWS will respond with a `403 Forbidden` status if a symlink is requested as well as it won't be shown in the directory listing if enabled.
 
-This feature is disabled by default and can be controlled by the boolean `--disable-symlinks` option or the equivalent [SERVER_DISABLE_SYMLINKS](./../configuration/environment-variables.md#server_disable_symlinks) env.
+This feature is enabled by default and can be controlled by the boolean `--disable-symlinks` option or the equivalent [SERVER_DISABLE_SYMLINKS](./../configuration/environment-variables.md#server_disable_symlinks) env.
 
-Here is an example of how to disable symlinks:
+Here is an example of how to enable symlinks following if wanted:
 
 ```sh
 static-web-server \
     -p=8787 -d=./public -g=trace \
     --directory-listing \
-    --disable-symlinks
+    --disable-symlinks=false
 ```

--- a/docs/content/features/ignore-files.md
+++ b/docs/content/features/ignore-files.md
@@ -4,16 +4,17 @@
 
 ## Ignore hidden files (dotfiles)
 
-SWS doesn't ignore dotfiles (hidden files) by default.
-However, it's possible to ignore those files as shown below. As a result, SWS will respond with a `404 Not Found` status.
+SWS *does ignore* dotfiles (hidden files) by default for security reasons.
 
-This feature is disabled by default and can be controlled by the boolean `--ignore-hidden-files` option or the equivalent [SERVER_IGNORE_HIDDEN_FILES](./../configuration/environment-variables.md#server_ignore_hidden_files) env.
+As a result, SWS will respond with a `404 Not Found` status as well as hidden files won't be shown in the directory listing if enabled.
 
-Here is an example of how to ignore hidden files:
+This feature is enabled by default and can be controlled by the boolean `--ignore-hidden-files` option or the equivalent [SERVER_IGNORE_HIDDEN_FILES](./../configuration/environment-variables.md#server_ignore_hidden_files) env.
+
+Here is an example of how to disable hidden files ignoring if wanted:
 
 ```sh
 static-web-server \
-    -p=8787 -d=tests/fixtures/public -g=trace \
-    --directory-listing=true \
-    --ignore-hidden-files true
+    -p=8787 -d=./public -g=trace \
+    --directory-listing \
+    --ignore-hidden-files=false
 ```

--- a/src/settings/cli.rs
+++ b/src/settings/cli.rs
@@ -495,7 +495,7 @@ pub struct General {
 
     #[arg(
         long,
-        default_value = "false",
+        default_value = "true",
         default_missing_value("true"),
         num_args(0..=1),
         require_equals(false),
@@ -507,7 +507,7 @@ pub struct General {
 
     #[arg(
         long,
-        default_value = "false",
+        default_value = "true",
         default_missing_value("true"),
         num_args(0..=1),
         require_equals(false),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Read the docs/PULL_REQUESTS.md -->

## Description
<!--- Describe your changes but try to be as concise as possible -->

This PR enables the `--ignore-hidden-files` and `--disable-symlinks`  options by default. This will make SWS safer since, for most use cases, it's better to avoid serving _hidden files_ and following _symlinks_ unless explicitly wanted.

**BREAKING:** Only if users rely on those feature options and the previous behaviour is desired should those be disabled explicitly.

The following options are now changed by default:

- `--ignore-hidden-files=true`
- `--disable-symlinks=true`

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- See how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
