### PR TITLE
Add internal priority support of dynamic compression encodings (#618)

### DIFF
--- a/docs/content/features/compression.md
+++ b/docs/content/features/compression.md
@@ -15,6 +15,12 @@ static-web-server \
 
 The compression algorithm is determined by the [`Accept-Encoding`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Encoding) header and the compression support built into SWS. By default SWS builds with support for `Gzip`, `Deflate`, `Brotli` and `Zstandard` algorithms.
 
+SWS honors the qualities specified by the client to choose the algorithm. In case of equal quality for several algorithms (or no qualities at all), the internal priority will select according to this priority list:
+1. `Zstandard`
+2. `Brotli`
+3. `Gzip`
+4. `Deflate`
+
 ## MIME types compressed
 
 Compression is only applied to files with the MIME types listed below, indicating text and similarly well compressing formats. The asterisk `*` is a placeholder indicating an arbitrary MIME type part.

--- a/docs/content/features/compression.md
+++ b/docs/content/features/compression.md
@@ -15,7 +15,8 @@ static-web-server \
 
 The compression algorithm is determined by the [`Accept-Encoding`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Encoding) header and the compression support built into SWS. By default SWS builds with support for `Gzip`, `Deflate`, `Brotli` and `Zstandard` algorithms.
 
-SWS honors the qualities specified by the client to choose the algorithm. In case of equal quality for several algorithms (or no qualities at all), the internal priority will select according to this priority list:
+SWS honors the qualities specified by the client to choose the algorithm. In case of equal quality for several algorithms (or no qualities at all), the internal priority will be selected according to this list:
+
 1. `Zstandard`
 2. `Brotli`
 3. `Gzip`

--- a/src/headers_ext/accept_encoding.rs
+++ b/src/headers_ext/accept_encoding.rs
@@ -64,8 +64,8 @@ mod tests {
         let accept_enc = AcceptEncoding(val.into());
 
         let mut encodings = accept_enc.sorted_encodings();
-        assert_eq!(encodings.next(), Some(ContentCoding::DEFLATE));
         assert_eq!(encodings.next(), Some(ContentCoding::GZIP));
+        assert_eq!(encodings.next(), Some(ContentCoding::DEFLATE));
         assert_eq!(encodings.next(), Some(ContentCoding::BROTLI));
         assert_eq!(encodings.next(), Some(ContentCoding::ZSTD));
         assert_eq!(encodings.next(), None);

--- a/src/headers_ext/content_coding.rs
+++ b/src/headers_ext/content_coding.rs
@@ -81,6 +81,20 @@ macro_rules! define_content_coding {
     }
 }
 
+impl ContentCoding {
+    pub fn priority(&self) -> u8 {
+        match self {
+            Self::IDENTITY => 1,
+            Self::COMPRESS => 2,
+            Self::DEFLATE => 3,
+            Self::GZIP => 4,
+            Self::BROTLI => 5,
+            Self::ZSTD => 6,
+            _ => 0,
+        }
+    }
+}
+
 define_content_coding! {
     BROTLI; "br",
     COMPRESS; "compress",


### PR DESCRIPTION
prioritizes modern compression algorithms while honoring client preferences

## Description
This will sort the accepted endcodings using both the client qualities and an intrernal priority.
It will prefer modern algorithms. 

## Related Issue
Closes #618

## Motivation and Context
Currenly the server will choose the compresion algorithm based solely on the qualities provided by the client.
Most browsers will not provide qualities, but just a list like `gzip, deflate, br, zstd`. 
In that case, the current sorting will not change the order and gzip will also be choosen, discarding more modern algorithms.

The internal priority as for now is:
- zstd (6)
- brotli (5)
- gzip (4)
- deflate (3)
- compress (2)
- none (1)

Given equal quality specified by the client, the encoding with the highest priorty will be put first in the sorted list and (if supported) will be used to compress the response.

## How Has This Been Tested?
Tested with curl and several combinations of accept-encoding
