### PR TITLE
Separate static pre-compression from dynamic compression features

### DIFF
--- a/docs/content/building-from-source.md
+++ b/docs/content/building-from-source.md
@@ -36,11 +36,11 @@ However, you can disable just the ones you don't need from the lists below.
 | [**HTTP2/TLS**](./features/http2-tls.md) |  |
 | `http2` | Activates the HTTP2 and TLS feature. |
 | [**Compression**](./features/compression.md) |  |
-| `compression` | Activates auto-compression and compression static with all supported algorithms. |
-| `compression-brotli` | Activates auto-compression/compression static with only the `brotli` algorithm. |
-| `compression-deflate` | Activates auto-compression/compression static with only the `deflate` algorithm. |
-| `compression-gzip` | Activates auto-compression/compression static with only the `gzip` algorithm. |
-| `compression-zstd` | Activates auto-compression/compression static with only the `zstd` algorithm. |
+| `compression` | Activates auto-compression with all supported algorithms. |
+| `compression-brotli` | Activates auto-compression with only the `brotli` algorithm. |
+| `compression-deflate` | Activates auto-compression with only the `deflate` algorithm. |
+| `compression-gzip` | Activates auto-compression with only the `gzip` algorithm. |
+| `compression-zstd` | Activates auto-compression with only the `zstd` algorithm. |
 | [**Directory Listing**](./features/directory-listing.md) |  |
 | `directory-listing` | Activates the directory listing feature. |
 | [**Basic Authorization**](./features/basic-authentication.md) |  |

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -21,7 +21,9 @@ use std::{
     feature = "compression-zstd",
     feature = "compression-deflate"
 ))]
-use crate::{compression, compression_static};
+use crate::compression;
+
+use crate::compression_static;
 
 #[cfg(feature = "basic-auth")]
 use crate::basic_auth;
@@ -342,13 +344,6 @@ impl RequestHandler {
             let resp = crate::markdown::post_process(uri_path_md.is_some(), &self.opts, resp)?;
 
             // Add a `Vary` header if static compression is used
-            #[cfg(any(
-                feature = "compression",
-                feature = "compression-gzip",
-                feature = "compression-brotli",
-                feature = "compression-zstd",
-                feature = "compression-deflate"
-            ))]
             let resp = compression_static::post_process(&self.opts, req, resp)?;
 
             // Auto compression based on the `Accept-Encoding` header

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,23 +131,6 @@ pub mod basic_auth;
     )))
 )]
 pub mod compression;
-#[cfg(any(
-    feature = "compression",
-    feature = "compression-gzip",
-    feature = "compression-brotli",
-    feature = "compression-zstd",
-    feature = "compression-deflate"
-))]
-#[cfg_attr(
-    docsrs,
-    doc(cfg(any(
-        feature = "compression",
-        feature = "compression-gzip",
-        feature = "compression-brotli",
-        feature = "compression-zstd",
-        feature = "compression-deflate"
-    )))
-)]
 pub mod compression_static;
 pub(crate) mod conditional_headers;
 pub mod control_headers;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,11 +81,11 @@
 //! [**HTTP2/TLS**](https://static-web-server.net/features/http2-tls/) |
 //! `http2` | Activates the HTTP2 and TLS feature.
 //! [**Compression**](https://static-web-server.net/features/compression/) |
-//! `compression` | Activates auto-compression and compression static with all supported algorithms.
-//! `compression-brotli` | Activates auto-compression/compression static with only the `brotli` algorithm.
-//! `compression-deflate` | Activates auto-compression/compression static with only the `deflate` algorithm.
-//! `compression-gzip` | Activates auto-compression/compression static with only the `gzip` algorithm.
-//! `compression-zstd` | Activates auto-compression/compression static with only the `zstd` algorithm.
+//! `compression` | Activates auto-compression with all supported algorithms.
+//! `compression-brotli` | Activates auto-compression with only the `brotli` algorithm.
+//! `compression-deflate` | Activates auto-compression with only the `deflate` algorithm.
+//! `compression-gzip` | Activates auto-compression with only the `gzip` algorithm.
+//! `compression-zstd` | Activates auto-compression with only the `zstd` algorithm.
 //! [**Directory Listing**](https://static-web-server.net/features/directory-listing/) |
 //! `directory-listing` | Activates the directory listing feature.
 //! [**Basic Authorization**](./features/basic-authentication.md) |

--- a/src/server.rs
+++ b/src/server.rs
@@ -43,7 +43,9 @@ use crate::fallback_page;
     feature = "compression-brotli",
     feature = "compression-zstd",
 ))]
-use crate::{compression, compression_static};
+use crate::compression;
+
+use crate::compression_static;
 
 #[cfg(feature = "basic-auth")]
 use crate::basic_auth;
@@ -346,13 +348,6 @@ impl Server {
         );
 
         // Check pre-compressed files based on the `Accept-Encoding` header
-        #[cfg(any(
-            feature = "compression",
-            feature = "compression-deflate",
-            feature = "compression-gzip",
-            feature = "compression-brotli",
-            feature = "compression-zstd",
-        ))]
         compression_static::init(general.compression_static, &mut handler_opts);
 
         // Auto compression based on the `Accept-Encoding` header

--- a/src/settings/cli.rs
+++ b/src/settings/cli.rs
@@ -296,23 +296,6 @@ pub struct General {
     /// Compression level to apply for Gzip, Deflate, Brotli or Zstd compression.
     pub compression_level: super::CompressionLevel,
 
-    #[cfg(any(
-        feature = "compression",
-        feature = "compression-gzip",
-        feature = "compression-brotli",
-        feature = "compression-zstd",
-        feature = "compression-deflate"
-    ))]
-    #[cfg_attr(
-        docsrs,
-        doc(cfg(any(
-            feature = "compression",
-            feature = "compression-gzip",
-            feature = "compression-brotli",
-            feature = "compression-zstd",
-            feature = "compression-deflate"
-        )))
-    )]
     #[arg(
         long,
         default_value = "false",

--- a/src/settings/file.rs
+++ b/src/settings/file.rs
@@ -257,23 +257,6 @@ pub struct General {
     pub compression_level: Option<CompressionLevel>,
 
     /// Check for a pre-compressed file on disk.
-    #[cfg(any(
-        feature = "compression",
-        feature = "compression-gzip",
-        feature = "compression-brotli",
-        feature = "compression-zstd",
-        feature = "compression-deflate"
-    ))]
-    #[cfg_attr(
-        docsrs,
-        doc(cfg(any(
-            feature = "compression",
-            feature = "compression-gzip",
-            feature = "compression-brotli",
-            feature = "compression-zstd",
-            feature = "compression-deflate"
-        )))
-    )]
     pub compression_static: Option<bool>,
 
     /// Error 404 pages.

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -146,13 +146,7 @@ impl Settings {
             feature = "compression-deflate"
         ))]
         let mut compression_level = opts.compression_level;
-        #[cfg(any(
-            feature = "compression",
-            feature = "compression-gzip",
-            feature = "compression-brotli",
-            feature = "compression-zstd",
-            feature = "compression-deflate"
-        ))]
+
         let mut compression_static = opts.compression_static;
 
         let mut page404 = opts.page404;
@@ -280,13 +274,6 @@ impl Settings {
                 if let Some(v) = general.compression_level {
                     compression_level = v
                 }
-                #[cfg(any(
-                    feature = "compression",
-                    feature = "compression-gzip",
-                    feature = "compression-brotli",
-                    feature = "compression-zstd",
-                    feature = "compression-deflate"
-                ))]
                 if let Some(v) = general.compression_static {
                     compression_static = v
                 }
@@ -647,13 +634,6 @@ impl Settings {
                     feature = "compression-deflate"
                 ))]
                 compression_level,
-                #[cfg(any(
-                    feature = "compression",
-                    feature = "compression-gzip",
-                    feature = "compression-brotli",
-                    feature = "compression-zstd",
-                    feature = "compression-deflate"
-                ))]
                 compression_static,
                 page404,
                 page50x,

--- a/src/static_files.rs
+++ b/src/static_files.rs
@@ -390,14 +390,10 @@ fn get_composed_file_metadata<'a>(
                 }
             }
 
-            let precompressed_variant = if compression_static {
-                match compression_static::precompressed_variant(file_path, headers) {
-                    Some(p) => Some((p.file_path, p.encoding)),
-                    None => None,
-                }
-            } else {
-                None
-            };
+            let precompressed_variant = compression_static
+                .then(|| compression_static::precompressed_variant(file_path, headers))
+                .flatten()
+                .map(|p| (p.file_path, p.encoding));
 
             Ok(FileMetadata {
                 file_path,

--- a/src/static_files.rs
+++ b/src/static_files.rs
@@ -25,13 +25,6 @@ use crate::response::response_body;
 #[cfg(feature = "experimental")]
 use crate::mem_cache::{cache, cache::MemCacheOpts};
 
-#[cfg(any(
-    feature = "compression",
-    feature = "compression-deflate",
-    feature = "compression-gzip",
-    feature = "compression-brotli",
-    feature = "compression-zstd"
-))]
 use crate::compression_static;
 
 #[cfg(feature = "directory-listing")]
@@ -102,15 +95,15 @@ pub struct StaticFileResponse {
 /// on file system and return a file response.
 pub async fn handle(opts: &HandleOpts<'_>) -> Result<StaticFileResponse, StatusCode> {
     let method = opts.method;
-    let uri_path = opts.uri_path;
-
     // Check if current HTTP method for incoming request is supported
     if !method.is_allowed() {
         return Err(StatusCode::METHOD_NOT_ALLOWED);
     }
 
-    let headers_opt = opts.headers;
+    let uri_path = opts.uri_path;
     let mut file_path = sanitize_path(opts.base_path, uri_path)?;
+
+    let headers_opt = opts.headers;
 
     // In-memory file cache feature with eviction policy
     #[cfg(feature = "experimental")]
@@ -337,8 +330,8 @@ pub async fn handle(opts: &HandleOpts<'_>) -> Result<StaticFileResponse, StatusC
 /// as well as its optional pre-compressed variant.
 fn get_composed_file_metadata<'a>(
     mut file_path: &'a mut PathBuf,
-    _headers: &'a HeaderMap<HeaderValue>,
-    _compression_static: bool,
+    headers: &'a HeaderMap<HeaderValue>,
+    compression_static: bool,
     mut index_files: &'a [&'a str],
 ) -> Result<FileMetadata<'a>, StatusCode> {
     tracing::trace!("getting metadata for file {}", file_path.display());
@@ -357,17 +350,9 @@ fn get_composed_file_metadata<'a>(
                     tracing::debug!("dir: appending {} to the directory path", index);
                     file_path.push(index);
 
-                    // Pre-compressed variant check for the autoindex
-                    #[cfg(any(
-                        feature = "compression",
-                        feature = "compression-deflate",
-                        feature = "compression-gzip",
-                        feature = "compression-brotli",
-                        feature = "compression-zstd"
-                    ))]
-                    if _compression_static {
+                    if compression_static {
                         if let Some(p) =
-                            compression_static::precompressed_variant(file_path, _headers)
+                            compression_static::precompressed_variant(file_path, headers)
                         {
                             return Ok(FileMetadata {
                                 file_path,
@@ -403,46 +388,28 @@ fn get_composed_file_metadata<'a>(
                 if !index_found && !index_files.is_empty() {
                     file_path.push(index_files.last().unwrap());
                 }
-            } else {
-                // Fallback pre-compressed variant check for the specific file
-                #[cfg(any(
-                    feature = "compression",
-                    feature = "compression-deflate",
-                    feature = "compression-gzip",
-                    feature = "compression-brotli",
-                    feature = "compression-zstd"
-                ))]
-                if _compression_static {
-                    if let Some(p) = compression_static::precompressed_variant(file_path, _headers)
-                    {
-                        return Ok(FileMetadata {
-                            file_path,
-                            metadata: p.metadata,
-                            is_dir: false,
-                            precompressed_variant: Some((p.file_path, p.encoding)),
-                        });
-                    }
-                }
             }
+
+            let precompressed_variant = if compression_static {
+                match compression_static::precompressed_variant(file_path, headers) {
+                    Some(p) => Some((p.file_path, p.encoding)),
+                    None => None,
+                }
+            } else {
+                None
+            };
 
             Ok(FileMetadata {
                 file_path,
                 metadata,
                 is_dir,
-                precompressed_variant: None,
+                precompressed_variant,
             })
         }
         Err(err) => {
             // Pre-compressed variant check for the file not found
-            #[cfg(any(
-                feature = "compression",
-                feature = "compression-deflate",
-                feature = "compression-gzip",
-                feature = "compression-brotli",
-                feature = "compression-zstd"
-            ))]
-            if _compression_static {
-                if let Some(p) = compression_static::precompressed_variant(file_path, _headers) {
+            if compression_static {
+                if let Some(p) = compression_static::precompressed_variant(file_path, headers) {
                     return Ok(FileMetadata {
                         file_path,
                         metadata: p.metadata,
@@ -476,9 +443,9 @@ fn get_composed_file_metadata<'a>(
                 }
                 _ => {
                     // Last pre-compressed variant check or the suffixed file not found
-                    if _compression_static {
+                    if compression_static {
                         if let Some(p) =
-                            compression_static::precompressed_variant(file_path, _headers)
+                            compression_static::precompressed_variant(file_path, headers)
                         {
                             return Ok(FileMetadata {
                                 file_path,


### PR DESCRIPTION

This enables SWS to deliver static precompressed files even if no compression features are enabled.

## Description
It separates compression features from static compression, as there are no compression algorithms needed to deliver already compressed files.

## Related Issue
This closes #362


## How Has This Been Tested?
Built and tested with compression features enabled and disabled. In both cases the server is able to deliver precompressed files.

