### PR TITLE
Add FIPS-capable TLS via http2-fips feature flag

### DIFF
--- a/.github/workflows/devel.code-analyzer.yml
+++ b/.github/workflows/devel.code-analyzer.yml
@@ -55,7 +55,7 @@ jobs:
     - name: Run clippy
       continue-on-error: true
       run: |
-        cargo clippy --all-features --message-format=json | clippy-sarif | tee rust-clippy-results.sarif | sarif-fmt
+        cargo clippy --features all --message-format=json | clippy-sarif | tee rust-clippy-results.sarif | sarif-fmt
 
     - name: Upload analysis results to GitHub
       uses: github/codeql-action/upload-sarif@v3

--- a/.github/workflows/devel.docker.fips.yml
+++ b/.github/workflows/devel.docker.fips.yml
@@ -1,0 +1,257 @@
+# Validates the FIPS Dockerfiles by exercising the build pipeline the
+# same way devel.docker.yml validates the non-FIPS Dockerfiles. The
+# build steps download a *-fips.tar.gz release artifact produced by
+# release.fips.yml, which does not exist until the first FIPS release
+# is published. `continue-on-error: true` on the build/push/inspect
+# steps suppresses the resulting failures until the first FIPS release
+# ships, after which the suppression should be removed so real build
+# regressions fail loudly.
+name: devel-docker-fips
+on:
+  merge_group:
+    branches:
+      - master
+  pull_request:
+    paths:
+      - docker/**/Dockerfile
+      - scripts/ci/**/*.sh
+      - .github/workflows/devel.docker.fips.yml
+  push:
+    branches:
+      - master
+    paths:
+      - docker/**/Dockerfile
+      - scripts/ci/**/*.sh
+      - .github/workflows/devel.docker.fips.yml
+
+env:
+  DOCKER_IMAGE: localhost:5000/github.com/static-web-server/static-web-server
+
+jobs:
+  docker-alpine-fips:
+    name: Docker test (fips-alpine)
+    strategy:
+      matrix:
+        arch:
+          - linux/amd64
+          - linux/arm64
+    runs-on: ubuntu-22.04
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
+    steps:
+      -
+        name: Dependencies
+        run: |
+          sudo apt-get install jq
+      -
+        name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+      -
+        name: Cache Docker layers
+        uses: actions/cache@v4
+        with:
+          path: /tmp/.buildx-cache
+          key: static-web-server-${{ matrix.arch }}-alpine-fips-buildx-${{ github.sha }}
+          restore-keys: |
+            static-web-server-${{ matrix.arch }}-alpine-fips-buildx-
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      -
+        name: Docker meta alpine-fips
+        id: meta_alpine_fips
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.DOCKER_IMAGE }}
+          flavor: |
+            latest=false
+            suffix=-fips-alpine
+          tags: |
+            type=schedule
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver-opts: network=host
+      -
+        name: Prepare Docker envs
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          scripts/ci/get_latest_release.sh
+          cat /tmp/version >> $GITHUB_ENV
+          cat /tmp/version
+          echo "SERVER_DOCKERFILE=./docker/alpine-fips/Dockerfile" >> $GITHUB_ENV
+      -
+        name: Build and export to Docker client
+        continue-on-error: true
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: ${{ matrix.arch }}
+          file: ${{ env.SERVER_DOCKERFILE }}
+          load: true
+          tags: ${{ steps.meta_alpine_fips.outputs.tags }}
+          labels: ${{ steps.meta_alpine_fips.outputs.labels }}
+          build-args: |
+            SERVER_VERSION=${{ env.SERVER_VERSION }}
+      -
+        name: Build and push to local registry
+        continue-on-error: true
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: ${{ matrix.arch }}
+          file: ${{ env.SERVER_DOCKERFILE }}
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta_alpine_fips.outputs.tags }}
+          labels: ${{ steps.meta_alpine_fips.outputs.labels }}
+          build-args: |
+            SERVER_VERSION=${{ env.SERVER_VERSION }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+      -
+        name: Inspect image
+        continue-on-error: true
+        run: |
+          docker image inspect ${{ env.DOCKER_IMAGE }}:${{ steps.meta_alpine_fips.outputs.version }}
+      -
+        name: Check manifest
+        if: github.event_name != 'pull_request'
+        continue-on-error: true
+        run: |
+          docker buildx imagetools inspect ${{ env.DOCKER_IMAGE }}:${{ steps.meta_alpine_fips.outputs.version }}
+      -
+        # Temp fix
+        # https://github.com/docker/build-push-action/issues/252
+        # https://github.com/moby/buildkit/issues/1896
+        name: Move cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+
+  docker-debian-fips:
+    name: Docker test (fips-debian)
+    strategy:
+      matrix:
+        arch:
+          - linux/amd64
+          - linux/arm64
+    runs-on: ubuntu-22.04
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
+    steps:
+      -
+        name: Dependencies
+        run: |
+          sudo apt-get install jq
+      -
+        name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+      -
+        name: Cache Docker layers
+        uses: actions/cache@v4
+        with:
+          path: /tmp/.buildx-cache
+          key: static-web-server-${{ matrix.arch }}-debian-fips-buildx-${{ github.sha }}
+          restore-keys: |
+            static-web-server-${{ matrix.arch }}-debian-fips-buildx-
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      -
+        name: Docker meta debian-fips
+        id: meta_debian_fips
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.DOCKER_IMAGE }}
+          flavor: |
+            latest=false
+            suffix=-fips-debian
+          tags: |
+            type=schedule
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver-opts: network=host
+      -
+        name: Prepare Docker envs
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          scripts/ci/get_latest_release.sh
+          cat /tmp/version >> $GITHUB_ENV
+          cat /tmp/version
+          echo "SERVER_DOCKERFILE=./docker/debian-fips/Dockerfile" >> $GITHUB_ENV
+      -
+        name: Build and export to Docker client
+        continue-on-error: true
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: ${{ matrix.arch }}
+          file: ${{ env.SERVER_DOCKERFILE }}
+          load: true
+          tags: ${{ steps.meta_debian_fips.outputs.tags }}
+          labels: ${{ steps.meta_debian_fips.outputs.labels }}
+          build-args: |
+            SERVER_VERSION=${{ env.SERVER_VERSION }}
+      -
+        name: Build and push to local registry
+        continue-on-error: true
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: ${{ matrix.arch }}
+          file: ${{ env.SERVER_DOCKERFILE }}
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta_debian_fips.outputs.tags }}
+          labels: ${{ steps.meta_debian_fips.outputs.labels }}
+          build-args: |
+            SERVER_VERSION=${{ env.SERVER_VERSION }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+      -
+        name: Inspect image
+        continue-on-error: true
+        run: |
+          docker image inspect ${{ env.DOCKER_IMAGE }}:${{ steps.meta_debian_fips.outputs.version }}
+      -
+        name: Check manifest
+        if: github.event_name != 'pull_request'
+        continue-on-error: true
+        run: |
+          docker buildx imagetools inspect ${{ env.DOCKER_IMAGE }}:${{ steps.meta_debian_fips.outputs.version }}
+      -
+        # Temp fix
+        # https://github.com/docker/build-push-action/issues/252
+        # https://github.com/moby/buildkit/issues/1896
+        name: Move cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/.github/workflows/devel.fips.yml
+++ b/.github/workflows/devel.fips.yml
@@ -1,0 +1,46 @@
+name: devel-fips
+
+on:
+  pull_request:
+    paths:
+      - "**.rs"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "Cross.fips.toml"
+      - ".github/workflows/devel.fips.yml"
+  push:
+    branches:
+      - master
+
+jobs:
+  test:
+    name: FIPS build check
+    runs-on: ubuntu-22.04
+    env:
+      CARGO_FEATURES: "--no-default-features --features http2-fips,compression,directory-listing,directory-listing-download,basic-auth,fallback-page,metrics,experimental"
+      RUSTFLAGS: "--cfg tokio_unstable"
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@stable
+
+    - name: Install FIPS build dependencies
+      run: sudo apt-get update && sudo apt-get install -y cmake golang
+
+    - name: Run tests
+      run: cargo test --verbose ${{ env.CARGO_FEATURES }}
+
+    - name: Build release binary
+      run: cargo build --bin static-web-server --release ${{ env.CARGO_FEATURES }}
+
+    - name: Verify binary is statically linked (no aws-lc shared objects)
+      run: |
+        echo "Checking linked libraries..."
+        ldd target/release/static-web-server
+        if ldd target/release/static-web-server | grep -q 'aws_lc'; then
+          echo "ERROR: aws-lc shared library detected -- FIPS module is not statically linked"
+          exit 1
+        fi
+        echo "OK: no aws-lc shared objects found"

--- a/.github/workflows/devel.fips.yml
+++ b/.github/workflows/devel.fips.yml
@@ -3,14 +3,22 @@ name: devel-fips
 on:
   pull_request:
     paths:
-      - "**.rs"
-      - "Cargo.toml"
-      - "Cargo.lock"
+      - Cargo.lock
+      - Cargo.toml
+      - src/**
+      - tests/**
       - "Cross.fips.toml"
       - ".github/workflows/devel.fips.yml"
   push:
     branches:
       - master
+    paths:
+      - Cargo.lock
+      - Cargo.toml
+      - src/**
+      - tests/**
+      - "Cross.fips.toml"
+      - ".github/workflows/devel.fips.yml"
 
 jobs:
   test:

--- a/.github/workflows/devel.fips.yml
+++ b/.github/workflows/devel.fips.yml
@@ -56,6 +56,9 @@ jobs:
     - name: Build release binary
       run: cargo build --bin static-web-server --release ${{ env.CARGO_FEATURES }}
 
+    - name: Verify binary has FIPS mode enabled
+      run: target/release/static-web-server -V | grep -i "fips"
+
     - name: Verify binary is statically linked (no aws-lc shared objects)
       run: |
         echo "Checking linked libraries..."

--- a/.github/workflows/devel.fips.yml
+++ b/.github/workflows/devel.fips.yml
@@ -17,7 +17,7 @@ jobs:
     name: FIPS build check
     runs-on: ubuntu-22.04
     env:
-      CARGO_FEATURES: "--no-default-features --features http2-fips,compression,directory-listing,directory-listing-download,basic-auth,fallback-page,metrics,experimental"
+      CARGO_FEATURES: "--no-default-features --features all-fips"
       RUSTFLAGS: "--cfg tokio_unstable"
     steps:
     - name: Checkout repository
@@ -62,7 +62,7 @@ jobs:
     name: FIPS rustdoc check
     runs-on: ubuntu-22.04
     env:
-      CARGO_FEATURES: "--no-default-features --features http2-fips,compression,directory-listing,directory-listing-download,basic-auth,fallback-page,metrics,experimental"
+      CARGO_FEATURES: "--no-default-features --features all-fips"
       RUSTFLAGS: "--cfg tokio_unstable"
     steps:
     - name: Checkout repository

--- a/.github/workflows/devel.fips.yml
+++ b/.github/workflows/devel.fips.yml
@@ -30,7 +30,7 @@ jobs:
         components: clippy
 
     - name: Install FIPS build dependencies
-      run: sudo apt-get update && sudo apt-get install -y cmake golang
+      run: sudo apt-get update && sudo apt-get install -y cmake golang libclang-dev
 
     # http2-ring and http2-fips are mutually exclusive providers, so
     # devel.yml's clippy job (which uses `--features all`, the ring
@@ -74,7 +74,7 @@ jobs:
         toolchain: nightly
 
     - name: Install FIPS build dependencies
-      run: sudo apt-get update && sudo apt-get install -y cmake golang
+      run: sudo apt-get update && sudo apt-get install -y cmake golang libclang-dev
 
     # Same provider-mutual-exclusion reasoning as the clippy step above:
     # devel.yml's rustdoc job exercises the ring provider via `--features

--- a/.github/workflows/devel.fips.yml
+++ b/.github/workflows/devel.fips.yml
@@ -25,9 +25,22 @@ jobs:
 
     - name: Install Rust
       uses: dtolnay/rust-toolchain@stable
+      with:
+        toolchain: stable
+        components: clippy
 
     - name: Install FIPS build dependencies
       run: sudo apt-get update && sudo apt-get install -y cmake golang
+
+    # http2-ring and http2-fips are mutually exclusive providers, so
+    # devel.yml's clippy job (which uses `--features all`, the ring
+    # provider) does not cover the FIPS code paths. Run clippy with the
+    # FIPS provider here so both providers are linted on every PR.
+    - name: Check via Clippy (FIPS)
+      run: cargo clippy ${{ env.CARGO_FEATURES }} -- -D warnings
+
+    - name: Check via Clippy (FIPS, tests)
+      run: cargo clippy ${{ env.CARGO_FEATURES }} --tests -- -D warnings
 
     - name: Run tests
       run: cargo test --verbose ${{ env.CARGO_FEATURES }}
@@ -44,3 +57,33 @@ jobs:
           exit 1
         fi
         echo "OK: no aws-lc shared objects found"
+
+  rustdoc:
+    name: FIPS rustdoc check
+    runs-on: ubuntu-22.04
+    env:
+      CARGO_FEATURES: "--no-default-features --features http2-fips,compression,directory-listing,directory-listing-download,basic-auth,fallback-page,metrics,experimental"
+      RUSTFLAGS: "--cfg tokio_unstable"
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Install nightly toolchain
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        toolchain: nightly
+
+    - name: Install FIPS build dependencies
+      run: sudo apt-get update && sudo apt-get install -y cmake golang
+
+    # Same provider-mutual-exclusion reasoning as the clippy step above:
+    # devel.yml's rustdoc job exercises the ring provider via `--features
+    # all`, so we exercise the FIPS provider here.
+    - name: Rustdoc build (FIPS)
+      run: |
+        cargo +nightly rustdoc --lib -Zrustdoc-map ${{ env.CARGO_FEATURES }} \
+            --config "build.rustflags=[\"--cfg\", \"tokio_unstable\"]" \
+            -Zhost-config -Ztarget-applies-to-host \
+            --config "host.rustflags=[\"--cfg\", \"tokio_unstable\"]" \
+            --config "build.rustdocflags=[\"--cfg\", \"docsrs\", \"--cfg\", \"docsrs\", \"--cfg\", \"tokio_unstable\", \"-Z\", \"unstable-options\", \"--emit=invocation-specific\", \"--cap-lints\", \"warn\", \"--extern-html-root-takes-precedence\"]" \
+            -Zunstable-options -- --document-private-items

--- a/.github/workflows/devel.yml
+++ b/.github/workflows/devel.yml
@@ -45,13 +45,18 @@ jobs:
       run: |
         cargo fmt --all -- --check tests/*.rs
 
+    # The `all` feature alias selects exactly one TLS crypto provider
+    # (http2-ring, the default). Using `--all-features` would enable both
+    # http2-ring and http2-fips simultaneously, which is rejected by a
+    # compile_error in src/tls.rs because the two providers are mutually
+    # exclusive. The FIPS provider is checked separately by devel-fips.
     - name: Check via Clippy
       run: |
-        cargo clippy --all-features -- -D warnings
+        cargo clippy --features all -- -D warnings
 
     - name: Check via Clippy (tests)
       run: |
-        cargo clippy --all-features --tests -- -D warnings
+        cargo clippy --features all --tests -- -D warnings
 
   test:
     name: Test
@@ -343,9 +348,12 @@ jobs:
         toolchain: nightly
         components: rustfmt, clippy
 
+    # `--features all` rather than `--all-features` for the same reason as
+    # the clippy job above: the http2-ring and http2-fips providers are
+    # mutually exclusive. FIPS rustdoc coverage lives in devel-fips.
     - name: Rustdoc build
       run: |
-        cargo +nightly rustdoc --lib -Zrustdoc-map --all-features \
+        cargo +nightly rustdoc --lib -Zrustdoc-map --features all \
             --config "build.rustflags=[\"--cfg\", \"tokio_unstable\"]" \
             -Zhost-config -Ztarget-applies-to-host \
             --config "host.rustflags=[\"--cfg\", \"tokio_unstable\"]" \

--- a/.github/workflows/release.crate.yml
+++ b/.github/workflows/release.crate.yml
@@ -36,4 +36,4 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_TOKEN }}
           RUSTDOCFLAGS: '--cfg=docsrs --deny=warnings'
-        run: cargo publish --all-features --package static-web-server
+        run: cargo publish --features all --package static-web-server

--- a/.github/workflows/release.docker.fips.yml
+++ b/.github/workflows/release.docker.fips.yml
@@ -1,0 +1,187 @@
+name: release-docker-fips
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  docker-image-fips-alpine:
+    runs-on: ubuntu-22.04
+    if: contains(github.ref, 'v2.')
+    steps:
+      -
+        name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      -
+        name: Docker meta fips-alpine
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            joseluisq/static-web-server
+            ghcr.io/static-web-server/static-web-server
+          flavor: |
+            latest=false
+            suffix=-fips-alpine
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Login to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      -
+        name: Prepare Docker envs
+        shell: bash
+        run: |
+          echo "SERVER_VERSION=${GITHUB_REF##*/v}" >> $GITHUB_ENV
+      -
+        name: Build and push (fips-alpine)
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          context: .
+          platforms: linux/amd64,linux/arm64
+          file: ./docker/alpine-fips/Dockerfile
+          tags: ${{ steps.meta.outputs.tags }}
+          build-args: |
+            SERVER_VERSION=${{ env.SERVER_VERSION }}
+
+  docker-image-fips-debian:
+    needs: ['docker-image-fips-alpine']
+    runs-on: ubuntu-22.04
+    if: contains(github.ref, 'v2.')
+    steps:
+      -
+        name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      -
+        name: Docker meta fips-debian
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            joseluisq/static-web-server
+            ghcr.io/static-web-server/static-web-server
+          flavor: |
+            latest=false
+            suffix=-fips-debian
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Login to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      -
+        name: Prepare Docker envs
+        shell: bash
+        run: |
+          echo "SERVER_VERSION=${GITHUB_REF##*/v}" >> $GITHUB_ENV
+      -
+        name: Build and push (fips-debian)
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          context: .
+          platforms: linux/amd64,linux/arm64
+          file: ./docker/debian-fips/Dockerfile
+          tags: ${{ steps.meta.outputs.tags }}
+          build-args: |
+            SERVER_VERSION=${{ env.SERVER_VERSION }}
+
+  docker-image-fips-scratch:
+    needs: ['docker-image-fips-alpine']
+    runs-on: ubuntu-22.04
+    steps:
+      -
+        name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      -
+        name: Docker meta fips-scratch
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            joseluisq/static-web-server
+            ghcr.io/static-web-server/static-web-server
+          flavor: |
+            latest=false
+            suffix=-fips
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Login to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      -
+        name: Prepare Docker envs
+        shell: bash
+        run: |
+          echo "SERVER_VERSION=${GITHUB_REF##*/v}" >> $GITHUB_ENV
+      -
+        name: Build and push (fips-scratch)
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          context: .
+          platforms: linux/amd64,linux/arm64
+          file: ./docker/scratch-fips/Dockerfile
+          tags: ${{ steps.meta.outputs.tags }}
+          build-args: |
+            SERVER_VERSION=${{ env.SERVER_VERSION }}

--- a/.github/workflows/release.fips.yml
+++ b/.github/workflows/release.fips.yml
@@ -1,0 +1,90 @@
+name: release-fips
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag (e.g. v2.42.0)"
+        required: true
+        type: string
+
+jobs:
+  build:
+    name: Build FIPS ${{ matrix.build }}
+    runs-on: ubuntu-22.04
+    env:
+      CARGO_FEATURES: "--no-default-features --features http2-fips,compression,directory-listing,directory-listing-download,basic-auth,fallback-page,metrics,experimental"
+      RUSTFLAGS: "--cfg tokio_unstable"
+      CROSS_CONFIG: "Cross.fips.toml"
+    strategy:
+      matrix:
+        build:
+          - linux-gnu-fips
+          - linux-gnu-arm64-fips
+          - linux-musl-fips
+          - linux-musl-arm64-fips
+        include:
+        - build: linux-gnu-fips
+          target: x86_64-unknown-linux-gnu
+        - build: linux-gnu-arm64-fips
+          target: aarch64-unknown-linux-gnu
+        - build: linux-musl-fips
+          target: x86_64-unknown-linux-musl
+        - build: linux-musl-arm64-fips
+          target: aarch64-unknown-linux-musl
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        targets: ${{ matrix.target }}
+
+    - name: Install cross
+      run: |
+        curl -sSL \
+          "https://github.com/cross-rs/cross/releases/download/v0.2.5/cross-x86_64-unknown-linux-musl.tar.gz" \
+          | sudo tar zxf - -C /usr/local/bin/ cross cross-util
+        cross -V
+
+    - name: Determine version
+      id: version
+      run: |
+        if [ "${{ github.event_name }}" = "release" ]; then
+          echo "version=${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
+        else
+          echo "version=${{ inputs.tag }}" >> $GITHUB_OUTPUT
+        fi
+
+    - name: Build release binary
+      run: |
+        cross build --bin static-web-server -vv --release \
+          ${{ env.CARGO_FEATURES }} \
+          --target=${{ matrix.target }}
+
+    - name: Build archive
+      run: |
+        staging="static-web-server-${{ steps.version.outputs.version }}-${{ matrix.target }}-fips"
+        mkdir -p "$staging/"
+        cp {README.md,LICENSE-APACHE,LICENSE-MIT} "$staging/"
+        cp "target/${{ matrix.target }}/release/static-web-server" "$staging/"
+        tar czf "$staging.tar.gz" "$staging"
+        echo "ASSET=$staging.tar.gz" >> $GITHUB_ENV
+
+    - name: Upload release archive
+      if: github.event_name == 'release'
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        gh release upload ${{ steps.version.outputs.version }} ${{ env.ASSET }}
+
+    - name: Upload artifact
+      if: github.event_name == 'workflow_dispatch'
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ matrix.build }}
+        path: ${{ env.ASSET }}

--- a/.github/workflows/release.fips.yml
+++ b/.github/workflows/release.fips.yml
@@ -15,7 +15,7 @@ jobs:
     name: Build FIPS ${{ matrix.build }}
     runs-on: ubuntu-22.04
     env:
-      CARGO_FEATURES: "--no-default-features --features http2-fips,compression,directory-listing,directory-listing-download,basic-auth,fallback-page,metrics,experimental"
+      CARGO_FEATURES: "--no-default-features --features all-fips"
       RUSTFLAGS: "--cfg tokio_unstable"
       CROSS_CONFIG: "Cross.fips.toml"
     strategy:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2355,6 +2355,7 @@ dependencies = [
  "anyhow",
  "async-compression",
  "async-tar",
+ "aws-lc-rs",
  "bcrypt",
  "bytes",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -286,6 +286,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-lc-fips-sys"
+version = "0.13.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3d619165468401dec3caa3366ebffbcb83f2f31883e5b3932f8e2dec2ddc568"
+dependencies = [
+ "bindgen",
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "regex",
+]
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+dependencies = [
+ "aws-lc-fips-sys",
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -308,6 +345,26 @@ dependencies = [
  "getrandom 0.3.4",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags 2.11.0",
+ "cexpr",
+ "clang-sys",
+ "itertools",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn",
 ]
 
 [[package]]
@@ -475,6 +532,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -499,6 +565,17 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common",
  "inout",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -593,6 +670,15 @@ checksum = "7e30ffc187e2e3aeafcd1c6e2aa416e29739454c0ccaa419226d5ecd181f2d78"
 dependencies = [
  "clap",
  "roff",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -757,6 +843,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -861,6 +959,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures-channel"
@@ -1333,6 +1437,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1395,6 +1508,16 @@ dependencies = [
  "libc",
  "libz-sys",
  "pkg-config",
+]
+
+[[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
 ]
 
 [[package]]
@@ -1547,6 +1670,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1565,6 +1694,16 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -1857,6 +1996,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1900,6 +2051,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbf2048e0e979efb2ca7b91c4f1a8d77c91853e9b987c94c555668a8994915ad"
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1918,6 +2075,7 @@ version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -1942,6 +2100,7 @@ version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,11 +38,16 @@ doc = false
 
 [features]
 # All features enabled by default
-default = ["compression", "http2", "directory-listing", "directory-listing-download", "basic-auth", "fallback-page", "metrics"]
+default = ["compression", "http2-ring", "directory-listing", "directory-listing-download", "basic-auth", "fallback-page", "metrics"]
 # Include all features (used when building SWS binaries)
 all = ["default", "experimental"]
-# HTTP2
-http2 = ["tokio-rustls", "rustls-pki-types"]
+# HTTP2 base TLS plumbing -- gates all TLS code via cfg(feature = "http2").
+# Does not select a crypto provider on its own.
+http2 = ["tokio-rustls", "rustls-pki-types", "tokio-rustls/logging", "tokio-rustls/tls12"]
+# HTTP2 with ring crypto provider (default)
+http2-ring = ["http2", "tokio-rustls/ring"]
+# HTTP2 with FIPS-validated crypto via aws-lc-rs
+http2-fips = ["http2", "tokio-rustls/fips"]
 # Compression
 compression = ["compression-brotli", "compression-deflate", "compression-gzip", "compression-zstd"]
 compression-brotli = ["async-compression/brotli"]
@@ -95,7 +100,7 @@ serde_json = "1.0"
 serde_repr = "0.1"
 shadow-rs = "1.4.0"
 tokio = { version = "1", default-features = false, features = ["rt-multi-thread", "macros", "fs", "io-util", "signal"] }
-tokio-rustls = { version = "0.26", optional = true, default-features = false, features = ["logging", "tls12", "ring"] }
+tokio-rustls = { version = "0.26", optional = true, default-features = false }
 tokio-util = { version = "0.7", default-features = false, features = ["compat", "io"] }
 toml = "0.9"
 tracing = { version = "0.1", default-features = false, features = ["std"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ http2 = ["tokio-rustls", "rustls-pki-types", "tokio-rustls/logging", "tokio-rust
 # HTTP2 with ring crypto provider (default)
 http2-ring = ["http2", "tokio-rustls/ring"]
 # HTTP2 with FIPS-validated crypto via aws-lc-rs
-http2-fips = ["http2", "tokio-rustls/fips"]
+http2-fips = ["http2", "tokio-rustls/fips", "aws-lc-rs"]
 # Compression
 compression = ["compression-brotli", "compression-deflate", "compression-gzip", "compression-zstd"]
 compression-brotli = ["async-compression/brotli"]
@@ -70,6 +70,7 @@ experimental = ["metrics", "tokio-metrics-collector", "compact_str", "mini-moka"
 [dependencies]
 aho-corasick = "1.1.4"
 anyhow = "1.0"
+aws-lc-rs = { version = "1", optional = true, default-features = false }
 async-compression = { version = "0.4", default-features = false, optional = true, features = ["brotli", "deflate", "gzip", "zstd", "tokio"] }
 async-tar = { version = "0.5.1", optional = true }
 bcrypt = { version = "0.18.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,7 +136,7 @@ rpath = false
 strip = true
 
 [package.metadata.docs.rs]
-all-features = true
+features = ["all"]
 rustdoc-args = ["--cfg", "docsrs", "--cfg", "tokio_unstable"]
 rustc-args = ["--cfg", "tokio_unstable"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,10 @@ doc = false
 default = ["compression", "http2-ring", "directory-listing", "directory-listing-download", "basic-auth", "fallback-page", "metrics"]
 # Include all features (used when building SWS binaries)
 all = ["default", "experimental"]
+# Default feature set with the FIPS crypto provider in place of ring.
+default-fips = ["compression", "http2-fips", "directory-listing", "directory-listing-download", "basic-auth", "fallback-page", "metrics"]
+# All features with the FIPS crypto provider (used when building FIPS SWS binaries).
+all-fips = ["default-fips", "experimental"]
 # HTTP2 base TLS plumbing -- gates all TLS code via cfg(feature = "http2").
 # Does not select a crypto provider on its own.
 http2 = ["tokio-rustls", "rustls-pki-types", "tokio-rustls/logging", "tokio-rustls/tls12"]

--- a/Cross.fips.toml
+++ b/Cross.fips.toml
@@ -1,17 +1,18 @@
 # Cross-compilation configuration for FIPS builds.
-# The FIPS crypto provider (aws-lc-fips-sys) requires CMake and Go at build time.
-# These pre-build commands install them into the cross Docker containers.
+# The FIPS crypto provider (aws-lc-fips-sys) requires CMake, Go, and libclang
+# (used by bindgen) at build time. These pre-build commands install them into
+# the cross Docker containers.
 #
 # Usage: set CROSS_CONFIG=Cross.fips.toml before invoking cross.
 
 [target.x86_64-unknown-linux-gnu]
-pre-build = ["apt-get update && apt-get install -y cmake golang"]
+pre-build = ["apt-get update && apt-get install -y cmake golang libclang-dev"]
 
 [target.x86_64-unknown-linux-musl]
-pre-build = ["apt-get update && apt-get install -y cmake golang"]
+pre-build = ["apt-get update && apt-get install -y cmake golang libclang-dev"]
 
 [target.aarch64-unknown-linux-gnu]
-pre-build = ["apt-get update && apt-get install -y cmake golang"]
+pre-build = ["apt-get update && apt-get install -y cmake golang libclang-dev"]
 
 [target.aarch64-unknown-linux-musl]
-pre-build = ["apt-get update && apt-get install -y cmake golang"]
+pre-build = ["apt-get update && apt-get install -y cmake golang libclang-dev"]

--- a/Cross.fips.toml
+++ b/Cross.fips.toml
@@ -1,0 +1,17 @@
+# Cross-compilation configuration for FIPS builds.
+# The FIPS crypto provider (aws-lc-fips-sys) requires CMake and Go at build time.
+# These pre-build commands install them into the cross Docker containers.
+#
+# Usage: set CROSS_CONFIG=Cross.fips.toml before invoking cross.
+
+[target.x86_64-unknown-linux-gnu]
+pre-build = ["apt-get update && apt-get install -y cmake golang"]
+
+[target.x86_64-unknown-linux-musl]
+pre-build = ["apt-get update && apt-get install -y cmake golang"]
+
+[target.aarch64-unknown-linux-gnu]
+pre-build = ["apt-get update && apt-get install -y cmake golang"]
+
+[target.aarch64-unknown-linux-musl]
+pre-build = ["apt-get update && apt-get install -y cmake golang"]

--- a/docker/alpine-fips/Dockerfile
+++ b/docker/alpine-fips/Dockerfile
@@ -1,0 +1,96 @@
+FROM --platform=$BUILDPLATFORM alpine:3.22.3 AS build
+
+ARG TARGETPLATFORM
+ARG SERVER_VERSION=0.0.0
+ENV SERVER_VERSION=${SERVER_VERSION}
+
+RUN set -eux \
+    && apk --no-cache add \
+        ca-certificates \
+        tzdata \
+        file \
+    && true
+
+RUN set -ex; \
+    case "$TARGETPLATFORM" in \
+        "linux/amd64") target='x86_64-unknown-linux-musl' ;; \
+        "linux/arm64") target='aarch64-unknown-linux-musl' ;; \
+        *) echo >&2 "error: unsupported $TARGETPLATFORM architecture for FIPS build"; exit 1 ;; \
+    esac; \
+    wget --quiet -O /tmp/static-web-server.tar.gz "https://github.com/static-web-server/static-web-server/releases/download/v${SERVER_VERSION}/static-web-server-v${SERVER_VERSION}-${target}-fips.tar.gz"; \
+    tar xzvf /tmp/static-web-server.tar.gz; \
+    cp static-web-server-v${SERVER_VERSION}-${target}-fips/static-web-server /usr/local/bin/; \
+    rm -rf /tmp/static-web-server.tar.gz static-web-server-v${SERVER_VERSION}-${target}-fips; \
+    chmod +x /usr/local/bin/static-web-server
+
+RUN set -ex \
+    && echo "Testing Docker image..." \
+    && uname -a \
+    && cat /etc/os-release \
+    && static-web-server --version \
+    && static-web-server --help \
+    && file /usr/local/bin/static-web-server \
+    && true
+
+FROM alpine:3.22.3
+
+ARG SERVER_VERSION=0.0.0
+ARG SERVER_USER_NAME=sws
+ARG SERVER_USER_ID=1000
+ARG SERVER_GROUP_NAME=sws
+ARG SERVER_GROUP_ID=1000
+
+ENV SERVER_VERSION=$SERVER_VERSION
+ENV SERVER_USER_ID=$SERVER_USER_ID
+ENV SERVER_USER_NAME=$SERVER_USER_NAME
+ENV SERVER_GROUP_ID=$SERVER_GROUP_ID
+ENV SERVER_GROUP_NAME=$SERVER_GROUP_NAME
+
+LABEL version="${SERVER_VERSION}" \
+    description="A cross-platform, high-performance and asynchronous web server for static files-serving. (FIPS build)" \
+    maintainer="Jose Quintana <joseluisq.net>"
+
+RUN set -eux \
+    && addgroup -g $SERVER_GROUP_ID $SERVER_GROUP_NAME \
+    && adduser -D -u $SERVER_USER_ID -G $SERVER_GROUP_NAME $SERVER_USER_NAME \
+    && true
+
+RUN set -eux \
+    && apk --no-cache add \
+        ca-certificates \
+        tzdata \
+    && true
+
+RUN set -eux \
+    && mkdir -p /home/$SERVER_USER_NAME/public \
+    && chown -R $SERVER_USER_NAME:$SERVER_GROUP_NAME /home/$SERVER_USER_NAME \
+    && ln -s /home/$SERVER_USER_NAME/public /var/public \
+    && chown -R $SERVER_USER_NAME:$SERVER_GROUP_NAME /var/public \
+    && true
+
+USER $SERVER_USER_NAME:$SERVER_GROUP_NAME
+
+COPY --from=build --chown=$SERVER_USER_NAME:$SERVER_GROUP_NAME \
+    /usr/local/bin/static-web-server /usr/local/bin/static-web-server
+COPY --chown=$SERVER_USER_NAME:$SERVER_GROUP_NAME \
+    ./docker/alpine/entrypoint.sh /usr/local/bin/entrypoint.sh
+COPY --chown=$SERVER_USER_NAME:$SERVER_GROUP_NAME \
+    ./docker/public /home/$SERVER_USER_NAME/public
+
+WORKDIR /home/$SERVER_USER_NAME
+
+EXPOSE 80
+
+STOPSIGNAL SIGQUIT
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+
+CMD ["static-web-server"]
+
+# Metadata
+LABEL org.opencontainers.image.vendor="Jose Quintana" \
+    org.opencontainers.image.url="https://github.com/static-web-server/static-web-server" \
+    org.opencontainers.image.title="Static Web Server (FIPS)" \
+    org.opencontainers.image.description="A cross-platform, high-performance and asynchronous web server for static files-serving. FIPS-validated TLS." \
+    org.opencontainers.image.version="${SERVER_VERSION}" \
+    org.opencontainers.image.documentation="https://static-web-server.net"

--- a/docker/debian-fips/Dockerfile
+++ b/docker/debian-fips/Dockerfile
@@ -1,0 +1,103 @@
+FROM --platform=$BUILDPLATFORM debian:13.3-slim AS build
+
+ARG TARGETPLATFORM
+ARG SERVER_VERSION=0.0.0
+ENV SERVER_VERSION=${SERVER_VERSION}
+
+RUN set -eux \
+    && DEBIAN_FRONTEND=noninteractive apt-get update -qq \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -qq -y --no-install-recommends --no-install-suggests \
+        ca-certificates \
+        curl \
+        file \
+        tzdata \
+    && true
+
+RUN set -ex \
+    && case "$TARGETPLATFORM" in \
+        "linux/amd64") target='x86_64-unknown-linux-gnu' ;; \
+        "linux/arm64") target='aarch64-unknown-linux-gnu' ;; \
+        *) echo >&2 "error: unsupported $TARGETPLATFORM architecture for FIPS build"; exit 1 ;; \
+    esac \
+    && curl -Lo /tmp/static-web-server.tar.gz \
+        "https://github.com/static-web-server/static-web-server/releases/download/v${SERVER_VERSION}/static-web-server-v${SERVER_VERSION}-${target}-fips.tar.gz" \
+    && tar xzvf /tmp/static-web-server.tar.gz \
+    && cp static-web-server-v${SERVER_VERSION}-${target}-fips/static-web-server /usr/local/bin/ \
+    && rm -rf /tmp/static-web-server.tar.gz static-web-server-v${SERVER_VERSION}-${target}-fips \
+    && chmod +x /usr/local/bin/static-web-server \
+    && true
+
+RUN set -ex \
+    && echo "Testing Docker image..." \
+    && uname -a \
+    && cat /etc/os-release \
+    && echo VERSION_NUMBER=$(cat /etc/debian_version) \
+    && echo TARGET_PLATFORM=$TARGETPLATFORM \
+    && file /usr/local/bin/static-web-server \
+    && true
+
+FROM debian:13.3-slim
+
+ARG SERVER_VERSION=0.0.0
+ARG SERVER_USER_NAME=sws
+ARG SERVER_USER_ID=1000
+ARG SERVER_GROUP_NAME=sws
+ARG SERVER_GROUP_ID=1000
+
+ENV SERVER_VERSION=$SERVER_VERSION
+ENV SERVER_USER_ID=$SERVER_USER_ID
+ENV SERVER_USER_NAME=$SERVER_USER_NAME
+ENV SERVER_GROUP_ID=$SERVER_GROUP_ID
+ENV SERVER_GROUP_NAME=$SERVER_GROUP_NAME
+
+LABEL version="${SERVER_VERSION}" \
+    description="A cross-platform, high-performance and asynchronous web server for static files-serving. (FIPS build)" \
+    maintainer="Jose Quintana <joseluisq.net>"
+
+RUN set -eux \
+    && groupadd -r -g $SERVER_GROUP_ID $SERVER_GROUP_NAME \
+    && useradd -r -g $SERVER_GROUP_ID -u $SERVER_USER_ID $SERVER_USER_NAME \
+    && true
+
+RUN set -eux \
+    && DEBIAN_FRONTEND=noninteractive apt-get update -qq \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -qq -y --no-install-recommends --no-install-suggests \
+        ca-certificates \
+        tzdata \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
+    && true
+
+RUN set -eux \
+    && mkdir -p /home/$SERVER_USER_NAME/public \
+    && chown -R $SERVER_USER_NAME:$SERVER_GROUP_NAME /home/$SERVER_USER_NAME \
+    && ln -s /home/$SERVER_USER_NAME/public /var/public \
+    && chown -R $SERVER_USER_NAME:$SERVER_GROUP_NAME /var/public \
+    && true
+
+USER $SERVER_USER_NAME:$SERVER_GROUP_NAME
+
+COPY --from=build --chown=$SERVER_USER_NAME:$SERVER_GROUP_NAME \
+    /usr/local/bin/static-web-server /usr/local/bin/static-web-server
+COPY --chown=$SERVER_USER_NAME:$SERVER_GROUP_NAME \
+    ./docker/debian/entrypoint.sh /usr/local/bin/entrypoint.sh
+COPY --chown=$SERVER_USER_NAME:$SERVER_GROUP_NAME \
+    ./docker/public /home/$SERVER_USER_NAME/public
+
+WORKDIR /home/$SERVER_USER_NAME
+
+EXPOSE 80
+
+STOPSIGNAL SIGQUIT
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+
+CMD ["static-web-server"]
+
+# Metadata
+LABEL org.opencontainers.image.vendor="Jose Quintana" \
+    org.opencontainers.image.url="https://github.com/static-web-server/static-web-server" \
+    org.opencontainers.image.title="Static Web Server (FIPS)" \
+    org.opencontainers.image.description="A cross-platform, high-performance and asynchronous web server for static files-serving. FIPS-validated TLS." \
+    org.opencontainers.image.version="${SERVER_VERSION}" \
+    org.opencontainers.image.documentation="https://static-web-server.net"

--- a/docker/scratch-fips/Dockerfile
+++ b/docker/scratch-fips/Dockerfile
@@ -1,0 +1,29 @@
+ARG SERVER_VERSION=0.0.0
+
+FROM ghcr.io/static-web-server/static-web-server:${SERVER_VERSION}-fips-alpine AS build
+
+FROM scratch
+
+ARG SERVER_VERSION=0.0.0
+ENV SERVER_VERSION=${SERVER_VERSION}
+
+LABEL version="${SERVER_VERSION}" \
+    description="A cross-platform, high-performance and asynchronous web server for static files-serving. (FIPS build)" \
+    maintainer="Jose Quintana <joseluisq.net>"
+
+COPY --from=build /usr/local/bin/static-web-server /
+COPY ./docker/public /public
+
+EXPOSE 80
+
+STOPSIGNAL SIGQUIT
+
+ENTRYPOINT ["/static-web-server"]
+
+# Metadata
+LABEL org.opencontainers.image.vendor="Jose Quintana" \
+    org.opencontainers.image.url="https://github.com/static-web-server/static-web-server" \
+    org.opencontainers.image.title="Static Web Server (FIPS)" \
+    org.opencontainers.image.description="A cross-platform, high-performance and asynchronous web server for static files-serving. FIPS-validated TLS." \
+    org.opencontainers.image.version="$SERVER_VERSION" \
+    org.opencontainers.image.documentation="https://static-web-server.net"

--- a/docs/content/building-from-source.md
+++ b/docs/content/building-from-source.md
@@ -34,7 +34,7 @@ However, you can disable just the ones you don't need from the lists below.
 | [**HTTP2/TLS**](./features/http2-tls.md) |  |
 | `http2` | Activates the HTTP2 and TLS feature. Requires exactly one of `http2-ring` or `http2-fips` to select a TLS crypto provider. |
 | `http2-ring` | Activates the HTTP2/TLS feature with [`ring`](https://github.com/briansmith/ring) as the TLS crypto provider. Included by default. |
-| `http2-fips` | Activates the HTTP2/TLS feature with [`aws-lc-rs`](https://github.com/aws/aws-lc-rs) in FIPS mode as the TLS crypto provider. Requires `cmake` and `go` at build time. Supported only on linux x86_64/aarch64 (gnu and musl). |
+| `http2-fips` | Activates the HTTP2/TLS feature with [`aws-lc-rs`](https://github.com/aws/aws-lc-rs) in FIPS mode as the TLS crypto provider. Requires `cmake`, `go`, and `libclang` at build time. Supported only on linux x86_64/aarch64 (gnu and musl). |
 | [**Compression**](./features/compression.md) |  |
 | `compression` | Activates auto-compression with all supported algorithms. |
 | `compression-brotli` | Activates auto-compression with only the `brotli` algorithm. |

--- a/docs/content/building-from-source.md
+++ b/docs/content/building-from-source.md
@@ -32,7 +32,9 @@ However, you can disable just the ones you don't need from the lists below.
 | `all` | Activates all available features including the `experimental` feature. This is the default feature used when building SWS binaries. |
 | `experimental` | Activates all SWS experimental features. Make sure to also provide the required `RUSTFLAGS` if the feature requires so. |
 | [**HTTP2/TLS**](./features/http2-tls.md) |  |
-| `http2` | Activates the HTTP2 and TLS feature. |
+| `http2` | Activates the HTTP2 and TLS feature. Requires exactly one of `http2-ring` or `http2-fips` to select a TLS crypto provider. |
+| `http2-ring` | Activates the HTTP2/TLS feature with [`ring`](https://github.com/briansmith/ring) as the TLS crypto provider. Included by default. |
+| `http2-fips` | Activates the HTTP2/TLS feature with [`aws-lc-rs`](https://github.com/aws/aws-lc-rs) in FIPS mode as the TLS crypto provider. Requires `cmake` and `go` at build time. Supported only on linux x86_64/aarch64 (gnu and musl). |
 | [**Compression**](./features/compression.md) |  |
 | `compression` | Activates auto-compression with all supported algorithms. |
 | `compression-brotli` | Activates auto-compression with only the `brotli` algorithm. |

--- a/docs/content/features/http2-tls.md
+++ b/docs/content/features/http2-tls.md
@@ -31,7 +31,7 @@ SWS comes with safe TLS defaults for underlying cryptography.
 
 These defaults are safe and useful for most use cases. See [Rustls safe defaults](https://docs.rs/rustls/0.21.1/rustls/struct.ConfigBuilder.html#method.with_safe_defaults) for more details.
 
-## FIPS-validated cryptography
+## FIPS-validated Cryptography
 
 For deployments that require FIPS 140-validated cryptography (US federal, regulated industries), SWS can be built with [`aws-lc-rs`](https://github.com/aws/aws-lc-rs) in FIPS mode as the TLS crypto provider, replacing the default [`ring`](https://github.com/briansmith/ring) backend. The underlying cryptographic module is [AWS-LC-FIPS](https://github.com/aws/aws-lc/tree/fips-2024-09-27).
 
@@ -48,8 +48,24 @@ The "Safe TLS defaults" listed above describe the `http2-ring` provider. The `ht
 To build from source with FIPS:
 
 ```sh
-cargo build --release --no-default-features \
-    --features http2-fips,compression,directory-listing,directory-listing-download,basic-auth,fallback-page,metrics
+cargo build -v --release --no-default-features \
+    --features="http2-fips,compression,directory-listing,directory-listing-download,basic-auth,fallback-page,metrics"
+```
+
+Alternatively, in case of build errors with GCC >= 14, try Clang as the C/C++ compiler:
+
+```sh
+env CC=clang CXX=clang++ cargo build -v --release --no-default-features \
+        --features="http2-fips,compression,directory-listing,directory-listing-download,basic-auth,fallback-page,metrics"
+```
+
+Finally, verify that the binary has been compiled with FIPS mode enabled:
+
+```sh
+$ static-web-server -V | grep -i "fips"
+# FIPS Mode:
+#   Module Version:   AWS-LC-FIPS 3.0.x
+#   Crypto Provider:  aws-lc-rs (via aws-lc-fips-sys)
 ```
 
 See the [Cargo features section](../building-from-source.md#cargo-features) for the full list of feature flags.

--- a/docs/content/features/http2-tls.md
+++ b/docs/content/features/http2-tls.md
@@ -31,6 +31,29 @@ SWS comes with safe TLS defaults for underlying cryptography.
 
 These defaults are safe and useful for most use cases. See [Rustls safe defaults](https://docs.rs/rustls/0.21.1/rustls/struct.ConfigBuilder.html#method.with_safe_defaults) for more details.
 
+## FIPS-validated cryptography
+
+For deployments that require FIPS 140-validated cryptography (US federal, regulated industries), SWS can be built with [`aws-lc-rs`](https://github.com/aws/aws-lc-rs) in FIPS mode as the TLS crypto provider, replacing the default [`ring`](https://github.com/briansmith/ring) backend. The underlying cryptographic module is [AWS-LC-FIPS](https://github.com/aws/aws-lc/tree/fips-2024-09-27).
+
+This is opt-in via the `http2-fips` Cargo feature flag, which is mutually exclusive with the default `http2-ring`. Pre-built FIPS binaries and container images are published alongside the regular release artifacts.
+
+The "Safe TLS defaults" listed above describe the `http2-ring` provider. The `http2-fips` provider's defaults are restricted to the subset of FIPS-approved ciphers (no ChaCha20-Poly1305) and FIPS-approved key exchange groups.
+
+!!! info "Build requirements"
+
+    - FIPS builds require `cmake` and `go` at build time. The compiled output is still a single statically-linked binary.
+    - Static linking is supported only on Linux x86_64 and aarch64, both `gnu` and `musl` toolchains.
+    - The FIPS feature does not change command-line flags, configuration, or the wire protocol; it only swaps the cryptographic backend.
+
+To build from source with FIPS:
+
+```sh
+cargo build --release --no-default-features \
+    --features http2-fips,compression,directory-listing,directory-listing-download,basic-auth,fallback-page,metrics
+```
+
+See the [Cargo features section](../building-from-source.md#cargo-features) for the full list of feature flags.
+
 ## Private key file formats
 
 Only the following private key file formats are supported:

--- a/docs/content/features/http2-tls.md
+++ b/docs/content/features/http2-tls.md
@@ -41,7 +41,7 @@ The "Safe TLS defaults" listed above describe the `http2-ring` provider. The `ht
 
 !!! info "Build requirements"
 
-    - FIPS builds require `cmake` and `go` at build time. The compiled output is still a single statically-linked binary.
+    - FIPS builds require `cmake`, `go`, and `libclang` (used by `bindgen` when compiling the FIPS module) at build time. The compiled output is still a single statically-linked binary.
     - Static linking is supported only on Linux x86_64 and aarch64, both `gnu` and `musl` toolchains.
     - The FIPS feature does not change command-line flags, configuration, or the wire protocol; it only swaps the cryptographic backend.
 

--- a/src/settings/cli_output.rs
+++ b/src/settings/cli_output.rs
@@ -18,6 +18,14 @@ pub fn display_version() -> Result {
     println!("Built:        {}", build::COMMIT_DATE);
     println!("Git commit:   {}", build::COMMIT_HASH);
     println!("Build target: {}", build::BUILD_TARGET);
+    #[cfg(feature = "http2-fips")]
+    {
+        if aws_lc_rs::try_fips_mode().is_ok() {
+            println!("FIPS Mode:");
+            println!("  Module Version:   AWS-LC-FIPS 3.0.x");
+            println!("  Crypto Provider:  aws-lc-rs (via aws-lc-fips-sys)");
+        }
+    }
     println!("Rust version: {}", build::RUST_VERSION);
     println!("License:      {}", env!("CARGO_PKG_LICENSE"));
     println!("Homepage:     {}", env!("CARGO_PKG_HOMEPAGE"));

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -393,4 +393,11 @@ mod tests {
             .build()
             .unwrap();
     }
+
+    #[cfg(feature = "http2-fips")]
+    #[test]
+    fn fips_mode_is_active() {
+        aws_lc_rs::try_fips_mode()
+            .expect("FIPS mode should be active when http2-fips feature is enabled");
+    }
 }

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -6,6 +6,15 @@
 //! The module handles requests over TLS via [Rustls](tokio_rustls::rustls).
 //!
 
+// Ensure exactly one TLS crypto provider is enabled.
+#[cfg(all(feature = "http2-ring", feature = "http2-fips"))]
+compile_error!(
+    "Only one TLS crypto provider may be enabled. Choose one of: http2-ring, http2-fips"
+);
+
+#[cfg(not(any(feature = "http2-ring", feature = "http2-fips")))]
+compile_error!("http2 requires a crypto provider: enable http2-ring or http2-fips");
+
 // Most of the file is borrowed from https://github.com/seanmonstar/warp/blob/master/src/tls.rs
 
 use futures_util::ready;


### PR DESCRIPTION
## Description

Proof of concept for FIPS-capable TLS support. Adds an `http2-fips` feature flag that uses `aws-lc-rs` in FIPS mode instead of `ring` as the TLS crypto provider, along with CI to build and ship FIPS binaries and Docker images. Targets are limited to the Linux platforms where `aws-lc-fips-sys` supports static linking (x86_64 and aarch64, gnu and musl), preserving the single-binary / scratch container property.

## Related Issue

#644

## Motivation and Context

SWS is well-positioned for high-compliance environments (US federal, regulated industries) thanks to its small codebase, scratch container images, and being in Rust. The missing piece is TLS using a FIPS-validated cryptographic module -- `ring` doesn't have FIPS validation.

`aws-lc-rs` is API-compatible with `ring` and provides bindings to the [AWS-LC FIPS module](https://github.com/aws/aws-lc). This PR restructures the `http2` feature into a base plus provider-specific features (`http2-ring` as the default, `http2-fips` as opt-in), so existing builds are completely unaffected. More detail and context on the FIPS landscape in #644.

## How Has This Been Tested?

- `cargo test --features=all` passes all 32 existing tests (default ring provider, unchanged behavior)
- `cargo test --no-default-features --features http2-fips,...` passes all 32 tests plus a new `fips_mode_is_active` test that asserts `aws_lc_rs::try_fips_mode()` returns `Ok`
- `cargo check --features http2-ring,http2-fips` correctly triggers `compile_error!` for conflicting providers
- `cargo check --no-default-features --features http2` correctly triggers `compile_error!` for missing provider
- `cargo check --no-default-features` compiles successfully (HTTP/1 only, no TLS)

## Some Other Notes

- The `github-advanced-security` bot raised an error on the mutually-exclusive feature flags. I'm not sure how we can avoid that, or if it's going to raise that error on every PR.