### PR TITLE
Separate TLS from HTTP2 feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1168,6 +1168,7 @@ dependencies = [
  "pin-project-lite",
  "smallvec",
  "tokio",
+ "want",
 ]
 
 [[package]]
@@ -1963,6 +1964,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2246,6 +2256,7 @@ dependencies = [
  "pin-project",
  "prometheus",
  "regex-lite",
+ "rustls-pemfile",
  "rustls-pki-types",
  "serde",
  "serde_ignored",
@@ -2595,6 +2606,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd69c5aa8f924c7519d6372789a74eac5b94fb0f8fcf0d4a97eb0bfc3e785f39"
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2716,6 +2733,15 @@ checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
+]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,6 +120,12 @@ windows-service = "0.8"
 [dev-dependencies]
 bytes = "1.11.1"
 serde_json = "1.0"
+hyper = { version = "1", default-features = false, features = ["http1", "http2", "client"] }
+hyper-util = { version = "0.1", default-features = false, features = ["tokio"] }
+http-body-util = "0.1"
+tokio-rustls = { version = "0.26", default-features = false, features = ["logging", "tls12", "ring"] }
+rustls-pki-types = "1.13"
+rustls-pemfile = "2"
 
 [build-dependencies]
 shadow-rs = "1.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,11 +38,13 @@ doc = false
 
 [features]
 # All features enabled by default
-default = ["compression", "http2", "directory-listing", "directory-listing-download", "basic-auth", "fallback-page", "metrics"]
+default = ["compression", "http2", "tls", "directory-listing", "directory-listing-download", "basic-auth", "fallback-page", "metrics"]
 # Include all features (used when building SWS binaries)
 all = ["default", "experimental"]
-# HTTP2
-http2 = ["tokio-rustls", "rustls-pki-types"]
+# TLS support (works with HTTP/1 and HTTP/2)
+tls = ["tokio-rustls", "rustls-pki-types"]
+# HTTP2 (requires TLS)
+http2 = ["tls"]
 # Compression
 compression = ["compression-brotli", "compression-deflate", "compression-gzip", "compression-zstd"]
 compression-brotli = ["async-compression/brotli"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ all = ["default", "experimental"]
 # TLS support (works with HTTP/1 and HTTP/2)
 tls = ["tokio-rustls", "rustls-pki-types"]
 # HTTP2 (requires TLS)
-http2 = ["tls"]
+http2 = ["tls", "hyper-util/http2"]
 # Compression
 compression = ["compression-brotli", "compression-deflate", "compression-gzip", "compression-zstd"]
 compression-brotli = ["async-compression/brotli"]
@@ -121,7 +121,7 @@ windows-service = "0.8"
 bytes = "1.11.1"
 serde_json = "1.0"
 hyper = { version = "1", default-features = false, features = ["http1", "http2", "client"] }
-hyper-util = { version = "0.1", default-features = false, features = ["tokio"] }
+hyper-util = { version = "0.1", default-features = false, features = ["tokio", "http2"] }
 http-body-util = "0.1"
 tokio-rustls = { version = "0.26", default-features = false, features = ["logging", "tls12", "ring"] }
 rustls-pki-types = "1.13"

--- a/docs/content/features/http-https-redirect.md
+++ b/docs/content/features/http-https-redirect.md
@@ -4,14 +4,14 @@
 
 This feature is disabled by default and can be controlled by the boolean `--https-redirect` option or the equivalent [SERVER_HTTPS_REDIRECT](./../configuration/environment-variables.md#server_https_redirect) env.
 
-!!! info "HTTP/2 required"
+!!! info "TLS required"
 
-    HTTPS redirect requires the [HTTP/2](../features/http2-tls.md) feature to be activated.
+    HTTPS redirect requires the [TLS](../features/tls.md) feature to be enabled.
 
 ## HTTPS redirect
 
 The boolean `--https-redirect` is the main option and controls the whole HTTPS redirect feature. If `true` then will tell SWS to redirect all requests with scheme `http` to `https` for the current server instance with a `301 Moved Permanently` redirect status response code.
-This option depends on [`http2`](../features/http2-tls.md) to be enabled.
+This option depends on [`tls`](../features/tls.md) to be enabled.
 
 ## HTTPS redirect host
 
@@ -37,10 +37,10 @@ Below is an example of the feature.
 
 ```sh
 static-web-server -p 4433 -d public/ -g trace \
-    # HTTP/2 + TLS options
-    --http2=true \
-    --http2-tls-cert=tests/tls/local.dev_cert.ecc.pem \
-    --http2-tls-key=tests/tls/local.dev_key.ecc.pem \
+    # TLS options
+    --tls \
+    --tls-cert=tests/tls/local.dev_cert.pem \
+    --tls-key=tests/tls/local.dev_key.pem \
 \
     # HTTPS redirect options
     --https-redirect=true \

--- a/docs/content/features/http2-tls.md
+++ b/docs/content/features/http2-tls.md
@@ -1,59 +1,27 @@
-# HTTP/2 and TLS
+# HTTP/2
 
-**`SWS`** provides [HTTP/2](https://en.wikipedia.org/wiki/HTTP/2) protocol and [TLS](https://en.wikipedia.org/wiki/Transport_Layer_Security) support.
+**`SWS`** provides [HTTP/2](https://en.wikipedia.org/wiki/HTTP/2) protocol support.
 
-This feature is disabled by default and can be activated via the boolean `-t, --http2` option as well as string arguments `--http2-tls-cert` (TLS certificate file path) and `--http2-tls-key` (private key file path).
-
-## Safe TLS defaults
-
-SWS comes with safe TLS defaults for underlying cryptography.
-
-- **Cipher suites:**
-    - TLS1.3:
-        ```
-        TLS13_AES_256_GCM_SHA384
-        TLS13_AES_128_GCM_SHA256
-        TLS13_CHACHA20_POLY1305_SHA256
-        ```
-    - TLS1.2:
-        ```
-        TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
-        TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
-        TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
-        TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
-        TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
-        TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
-        ```
-- **Key exchange groups:**
-    - `X25519`, `SECP256R1` and `SECP384R1`
-- **Protocol versions:**
-    - TLS `1.2` and `1.3`
-
-These defaults are safe and useful for most use cases. See [Rustls safe defaults](https://docs.rs/rustls/0.21.1/rustls/struct.ConfigBuilder.html#method.with_safe_defaults) for more details.
-
-## Private key file formats
-
-Only the following private key file formats are supported:
-
-- **RSA Private Key:** A DER-encoded plaintext RSA private key as specified in [PKCS#1/RFC3447](https://datatracker.ietf.org/doc/html/rfc3447).
-- **PKCS8 Private Key:** A DER-encoded plaintext private key as specified in [PKCS#8/RFC5958](https://datatracker.ietf.org/doc/rfc5958/).
-- **EC Private Key:** A Sec1-encoded plaintext private key as specified in [RFC5915](https://www.rfc-editor.org/rfc/rfc5915).
-
-## Example
+This feature is disabled by default and can be activated via the boolean `--http2` option. HTTP/2 requires [TLS](./tls.md) to be enabled; pass `--tls`, `--tls-cert` and `--tls-key` alongside `--http2`.
 
 !!! info "Tips"
 
-    - Either `--host`, `--port` and `--root` have defaults (optional values) so they can be specified or omitted as required.
-    - Don't forget to adjust the proper `--port` value for the HTTP/2 & TLS feature.
-    - When this feature is enabled (`--http2=true`) then the [security headers](./security-headers.md) are also enabled automatically.
+    - `--http2` requires TLS. Always pass `--tls --tls-cert <path> --tls-key <path>` together with `--http2`.
+    - When HTTP/2 is enabled, [Security Headers](./security-headers.md) are also enabled automatically (via TLS).
+    - See the [TLS](./tls.md) page for supported key formats and cipher suite defaults.
     - The server provides [Termination Signal](https://www.gnu.org/software/libc/manual/html_node/Termination-Signals.html) handling with [Graceful Shutdown](https://cloud.google.com/blog/products/containers-kubernetes/kubernetes-best-practices-terminating-with-grace) ability by default.
+
+## Example
+
+Below is an example of how to run the server with HTTP/2 over TLS.
 
 ```sh
 static-web-server \
     --host 127.0.0.1 \
     --port 8787 \
     --root ./my-public-dir \
-    --http2 true \
-    --http2-tls-cert ./my-tls.cert \
-    --http2-tls-key ./my-tls.key
+    --tls \
+    --tls-cert ./my-tls.cert \
+    --tls-key ./my-tls.key \
+    --http2
 ```

--- a/docs/content/features/security-headers.md
+++ b/docs/content/features/security-headers.md
@@ -2,7 +2,7 @@
 
 **`SWS`** provides several [security headers](https://web.dev/security-headers/) support.
 
-When the [HTTP/2](../features/http2-tls.md) feature is activated *security headers* are enabled automatically.
+When the [TLS](../features/tls.md) feature is activated *security headers* are enabled automatically.
 
 This feature is disabled by default on HTTP/1 and can be controlled by the boolean `--security-headers` option or the equivalent [SERVER_SECURITY_HEADERS](./../configuration/environment-variables.md#server_security_headers) env.
 

--- a/docs/content/features/tls.md
+++ b/docs/content/features/tls.md
@@ -1,0 +1,62 @@
+# TLS
+
+**`SWS`** provides [TLS](https://en.wikipedia.org/wiki/Transport_Layer_Security) support for serving content over encrypted HTTPS connections.
+
+This feature is disabled by default and can be activated via the boolean `-t, --tls` option along with `--tls-cert` (path to the TLS certificate file) and `--tls-key` (path to the private key file). It works with both HTTP/1 and [HTTP/2](./http2-tls.md).
+
+!!! info "Tips"
+
+    - When TLS is enabled, [Security Headers](./security-headers.md) are also enabled automatically.
+    - Combine `--tls` with `--http2` to serve [HTTP/2](./http2-tls.md) over TLS.
+    - The [HTTP to HTTPS redirect](./http-https-redirect.md) feature also requires TLS to be enabled.
+
+## Safe TLS defaults
+
+SWS uses safe TLS defaults backed by [Rustls](https://github.com/rustls/rustls).
+
+- **Cipher suites:**
+    - TLS 1.3:
+        ```
+        TLS13_AES_256_GCM_SHA384
+        TLS13_AES_128_GCM_SHA256
+        TLS13_CHACHA20_POLY1305_SHA256
+        ```
+    - TLS 1.2:
+        ```
+        TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+        TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+        TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
+        TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+        TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+        TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+        ```
+- **Key exchange groups:** `X25519`, `SECP256R1`, `SECP384R1`
+- **Protocol versions:** TLS 1.2 and 1.3
+
+## Private key file formats
+
+Only the following private key file formats are supported:
+
+- **RSA Private Key:** DER-encoded as specified in [PKCS#1/RFC3447](https://datatracker.ietf.org/doc/html/rfc3447).
+- **PKCS8 Private Key:** DER-encoded as specified in [PKCS#8/RFC5958](https://datatracker.ietf.org/doc/rfc5958/).
+- **EC Private Key:** Sec1-encoded as specified in [RFC5915](https://www.rfc-editor.org/rfc/rfc5915).
+
+## Example
+
+Below is an example of how to run the server with TLS enabled (HTTP/1 over TLS).
+
+!!! info "Tips"
+
+    - Either `--host`, `--port` and `--root` have defaults (optional values) so they can be specified or omitted as required.
+    - Don't forget to adjust the proper `--port` value when TLS is enabled.
+    - The server provides [Termination Signal](https://www.gnu.org/software/libc/manual/html_node/Termination-Signals.html) handling with [Graceful Shutdown](https://cloud.google.com/blog/products/containers-kubernetes/kubernetes-best-practices-terminating-with-grace) ability by default.
+
+```sh
+static-web-server \
+    --host 127.0.0.1 \
+    --port 8787 \
+    --root ./my-public-dir \
+    --tls \
+    --tls-cert ./my-tls.cert \
+    --tls-key ./my-tls.key
+```

--- a/docs/docker-compose.yml
+++ b/docs/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     build:
       dockerfile: Dockerfile
     ports:
-      - 8000:8000
+      - 8200:8000
     volumes:
       - ../.git:/docs/.git
       - ./content:/docs/docs/content

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -138,7 +138,8 @@ nav:
   - 'Features':
     - 'HTTP/1': 'features/http1.md'
     - 'HTTP Methods': 'features/http-methods.md'
-    - 'HTTP/2 and TLS': 'features/http2-tls.md'
+    - 'TLS': 'features/tls.md'
+    - 'HTTP/2': 'features/http2-tls.md'
     - 'HTTP to HTTPS redirect': 'features/http-https-redirect.md'
     - 'Logging': 'features/logging.md'
     - 'Compression': 'features/compression.md'

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,8 +153,8 @@ pub(crate) mod fs;
 pub mod handler;
 pub(crate) mod headers_ext;
 pub(crate) mod health;
-#[cfg(feature = "http2")]
-#[cfg_attr(docsrs, doc(cfg(feature = "http2")))]
+#[cfg(feature = "tls")]
+#[cfg_attr(docsrs, doc(cfg(feature = "tls")))]
 pub mod https_redirect;
 pub(crate) mod log_addr;
 pub mod maintenance_mode;
@@ -174,8 +174,8 @@ pub mod settings;
 #[cfg_attr(docsrs, doc(cfg(any(unix, windows))))]
 pub mod signals;
 pub mod static_files;
-#[cfg(feature = "http2")]
-#[cfg_attr(docsrs, doc(cfg(feature = "http2")))]
+#[cfg(feature = "tls")]
+#[cfg_attr(docsrs, doc(cfg(feature = "tls")))]
 pub mod tls;
 pub(crate) mod virtual_hosts;
 #[cfg(windows)]

--- a/src/server/http1.rs
+++ b/src/server/http1.rs
@@ -36,7 +36,7 @@ pub(super) async fn run<F: FnOnce()>(
         .with_context(|| "failed to create tokio::net::TcpListener")?;
 
     let graceful = GracefulShutdown::new();
-    let http = http1::Builder::new();
+    let builder = http1::Builder::new();
 
     #[cfg(unix)]
     let signals =
@@ -86,7 +86,7 @@ pub(super) async fn run<F: FnOnce()>(
                     tracing::warn!("failed to enable TCP_NODELAY for {}: {:?}", addr, e);
                 }
                 let svc = router.build(Some(addr));
-                let conn = http.serve_connection(TokioIo::new(stream), svc);
+                let conn = builder.serve_connection(TokioIo::new(stream), svc);
                 tokio::spawn(graceful.watch(conn));
             }
             _ = &mut shutdown => { break; }
@@ -100,8 +100,11 @@ pub(super) async fn run<F: FnOnce()>(
 
     #[cfg(windows)]
     {
-        let (r0,) = tokio::try_join!(ctx.ctrlc_task)?;
-        r0?;
+        // Abort the Ctrl+C listener task since it could still be blocked on
+        // `ctrl_c().await` when shutdown was triggered programmatically (e.g.
+        // via `cancel_recv`). Aborting is a no-op if it already completed due
+        // to a real Ctrl+C being received.
+        ctx.ctrlc_task.abort();
         _cancel_fn();
     }
 

--- a/src/server/http1.rs
+++ b/src/server/http1.rs
@@ -53,13 +53,14 @@ pub(super) async fn run<F: FnOnce()>(
 
     #[cfg(windows)]
     let shutdown = {
-        let cancel_recv = if ctx.windows_service {
-            Arc::new(Mutex::new(ctx.cancel_recv))
+        let ctrl_c_recv = Arc::new(Mutex::new(if !ctx.windows_service {
+            Some(ctx.ctrl_c_recv)
         } else {
-            Arc::new(Mutex::new(Some(ctx.ctrl_c_recv)))
-        };
+            None
+        }));
+        let cancel_recv = Arc::new(Mutex::new(ctx.cancel_recv));
         let grace_period = ctx.grace_period;
-        async move { signals::wait_for_ctrl_c(cancel_recv, grace_period).await }
+        async move { signals::wait_for_ctrl_c_or_cancel(ctrl_c_recv, cancel_recv, grace_period).await }
     };
     #[cfg(windows)]
     tokio::pin!(shutdown);

--- a/src/server/http1_tls.rs
+++ b/src/server/http1_tls.rs
@@ -144,10 +144,15 @@ pub(super) async fn run<F: FnOnce()>(
 
     #[cfg(windows)]
     {
-        let (r0, r1, r2) = tokio::try_join!(ctx.ctrlc_task, http1_task, redirect_task)?;
+        let (r0, r1) = tokio::try_join!(http1_task, redirect_task)?;
+        // NOTE: Abort the Ctrl+C listener task since
+        // it could still be blocked on `ctrl_c().await` when
+        // shutdown was triggered programmatically (e.g. via `cancel_recv`).
+        // Aborting is a no-op if it already completed
+        // due to a real Ctrl+C was received.
+        ctx.ctrlc_task.abort();
         r0?;
         r1?;
-        r2?;
     }
     #[cfg(unix)]
     {

--- a/src/server/http1_tls.rs
+++ b/src/server/http1_tls.rs
@@ -3,8 +3,9 @@
 // See https://static-web-server.net/ for more information
 // Copyright (C) 2019-present Jose Quintana <joseluisq.net>
 
-//! HTTP/2 + TLS server accept-loop with optional HTTP to HTTPS redirect.
+//! HTTP/1 + TLS server accept-loop with optional HTTP to HTTPS redirect.
 
+use hyper::server::conn::http1;
 use hyper_util::rt::TokioIo;
 use hyper_util::server::graceful::GracefulShutdown;
 use std::net::TcpListener;
@@ -20,7 +21,7 @@ use crate::signals;
 
 use super::{ShutdownCtx, TlsConfig, redirect};
 
-/// Run the HTTP/2 + TLS accept loop with an optional HTTP → HTTPS redirect server.
+/// Run the HTTP/1 + TLS accept loop with an optional HTTP to HTTPS redirect server.
 pub(super) async fn run<F: FnOnce()>(
     tcp_listener: TcpListener,
     router: RouterService,
@@ -79,13 +80,11 @@ pub(super) async fn run<F: FnOnce()>(
     )?
     .unwrap_or_else(|| tokio::spawn(async { Ok::<_, crate::Error>(()) }));
 
-    // HTTP/2 + TLS accept-loop task
-    let http2_task = tokio::spawn({
+    let http1_task = tokio::spawn({
         let router = router.clone();
         async move {
             let graceful = GracefulShutdown::new();
-            let builder =
-                hyper_util::server::conn::auto::Builder::new(hyper_util::rt::TokioExecutor::new());
+            let http = http1::Builder::new();
 
             #[cfg(unix)]
             let shutdown = signals::wait_for_signals(signals, grace_period, cancel_recv);
@@ -113,21 +112,16 @@ pub(super) async fn run<F: FnOnce()>(
                                 continue;
                             }
                         };
-                        let _ = stream.set_nodelay(true);
+                         if let Err(e) = stream.set_nodelay(true) {
+                            tracing::warn!("failed to enable TCP_NODELAY for {}: {:?}", addr, e);
+                        }
                         let tls_acceptor = tls_acceptor.clone();
                         let svc = router.build(Some(addr));
                         match tls_acceptor.accept(stream).await {
                             Ok(tls_stream) => {
-                                let watcher = graceful.watcher();
-                                let builder_clone = builder.clone();
-                                tokio::spawn(async move {
-                                    let conn = builder_clone
-                                        .serve_connection(TokioIo::new(tls_stream), svc)
-                                        .into_owned();
-                                    if let Err(e) = watcher.watch(conn).await {
-                                        tracing::debug!("TLS connection error: {:?}", e);
-                                    }
-                                });
+                                let conn = http
+                                    .serve_connection(TokioIo::new(tls_stream), svc);
+                                tokio::spawn(graceful.watch(conn));
                             }
                             Err(e) => {
                                 tracing::debug!(
@@ -147,21 +141,21 @@ pub(super) async fn run<F: FnOnce()>(
 
     tracing::info!(
         parent: tracing::info_span!("Server::start_server", ?addr_str, ?threads),
-        "http2 server is listening on https://{}",
+        "http1 tls server is listening on https://{}",
         addr_str
     );
-    tracing::info!("press ctrl+c to shut down the servers");
+    tracing::info!("press ctrl+c to shut down the server");
 
     #[cfg(windows)]
     {
-        let (r0, r1, r2) = tokio::try_join!(ctx.ctrlc_task, http2_task, redirect_task)?;
+        let (r0, r1, r2) = tokio::try_join!(ctx.ctrlc_task, http1_task, redirect_task)?;
         r0?;
         r1?;
         r2?;
     }
     #[cfg(unix)]
     {
-        let (r0, r1) = tokio::try_join!(http2_task, redirect_task)?;
+        let (r0, r1) = tokio::try_join!(http1_task, redirect_task)?;
         r0?;
         r1?;
     }

--- a/src/server/http1_tls.rs
+++ b/src/server/http1_tls.rs
@@ -62,11 +62,13 @@ pub(super) async fn run<F: FnOnce()>(
     #[cfg(windows)]
     let redirect_cancel_recv = cancel_recv.clone();
     #[cfg(windows)]
-    let ctrl_c_recv = Arc::new(Mutex::new(Some(ctx.ctrl_c_recv)));
+    let ctrl_c_recv = Arc::new(Mutex::new(if !ctx.windows_service {
+        Some(ctx.ctrl_c_recv)
+    } else {
+        None
+    }));
     #[cfg(windows)]
     let redirect_ctrl_c_recv = ctrl_c_recv.clone();
-    #[cfg(windows)]
-    let windows_service = ctx.windows_service;
 
     // Optional HTTP → HTTPS redirect server
     let redirect_task = redirect::maybe_spawn(
@@ -74,8 +76,6 @@ pub(super) async fn run<F: FnOnce()>(
         redirect_cancel_recv,
         #[cfg(windows)]
         redirect_ctrl_c_recv,
-        #[cfg(windows)]
-        windows_service,
         grace_period,
     )?
     .unwrap_or_else(|| tokio::spawn(async { Ok::<_, crate::Error>(()) }));
@@ -93,11 +93,7 @@ pub(super) async fn run<F: FnOnce()>(
 
             #[cfg(windows)]
             let shutdown = async move {
-                if windows_service {
-                    signals::wait_for_ctrl_c(cancel_recv, grace_period).await;
-                } else {
-                    signals::wait_for_ctrl_c(ctrl_c_recv, grace_period).await;
-                }
+                signals::wait_for_ctrl_c_or_cancel(ctrl_c_recv, cancel_recv, grace_period).await;
             };
             #[cfg(windows)]
             tokio::pin!(shutdown);
@@ -112,7 +108,7 @@ pub(super) async fn run<F: FnOnce()>(
                                 continue;
                             }
                         };
-                         if let Err(e) = stream.set_nodelay(true) {
+                        if let Err(e) = stream.set_nodelay(true) {
                             tracing::warn!("failed to enable TCP_NODELAY for {}: {:?}", addr, e);
                         }
                         let tls_acceptor = tls_acceptor.clone();

--- a/src/server/http1_tls.rs
+++ b/src/server/http1_tls.rs
@@ -31,11 +31,13 @@ pub(super) async fn run<F: FnOnce()>(
     ctx: ShutdownCtx,
     _cancel_fn: F,
 ) -> Result {
-    let tls = TlsConfigBuilder::new()
+    let mut tls = TlsConfigBuilder::new()
         .cert_path(&cfg.tls_cert)
         .key_path(&cfg.tls_key)
         .build()
         .with_context(|| "failed to initialize TLS probably because invalid cert or key file")?;
+    tls.alpn_protocols = vec![b"http/1.1".to_vec()];
+
     let tls_acceptor = TlsAcceptor::new(tls);
 
     tcp_listener
@@ -70,7 +72,7 @@ pub(super) async fn run<F: FnOnce()>(
     #[cfg(windows)]
     let redirect_ctrl_c_recv = ctrl_c_recv.clone();
 
-    // Optional HTTP → HTTPS redirect server
+    // Optional HTTP to HTTPS redirect server
     let redirect_task = redirect::maybe_spawn(
         &cfg,
         redirect_cancel_recv,
@@ -84,7 +86,7 @@ pub(super) async fn run<F: FnOnce()>(
         let router = router.clone();
         async move {
             let graceful = GracefulShutdown::new();
-            let http = http1::Builder::new();
+            let builder = http1::Builder::new();
 
             #[cfg(unix)]
             let shutdown = signals::wait_for_signals(signals, grace_period, cancel_recv);
@@ -115,7 +117,7 @@ pub(super) async fn run<F: FnOnce()>(
                         let svc = router.build(Some(addr));
                         match tls_acceptor.accept(stream).await {
                             Ok(tls_stream) => {
-                                let conn = http
+                                let conn = builder
                                     .serve_connection(TokioIo::new(tls_stream), svc);
                                 tokio::spawn(graceful.watch(conn));
                             }

--- a/src/server/http2.rs
+++ b/src/server/http2.rs
@@ -152,10 +152,15 @@ pub(super) async fn run<F: FnOnce()>(
 
     #[cfg(windows)]
     {
-        let (r0, r1, r2) = tokio::try_join!(ctx.ctrlc_task, http2_task, redirect_task)?;
+        let (r0, r1) = tokio::try_join!(http2_task, redirect_task)?;
+        // NOTE: Abort the Ctrl+C listener task since
+        // it could still be blocked on `ctrl_c().await` when
+        // shutdown was triggered programmatically (e.g. via `cancel_recv`).
+        // Aborting is a no-op if it already completed
+        // due to a real Ctrl+C was received.
+        ctx.ctrlc_task.abort();
         r0?;
         r1?;
-        r2?;
     }
     #[cfg(unix)]
     {

--- a/src/server/http2.rs
+++ b/src/server/http2.rs
@@ -5,7 +5,8 @@
 
 //! HTTP/2 + TLS server accept-loop with optional HTTP to HTTPS redirect.
 
-use hyper_util::rt::TokioIo;
+use hyper::server::conn::http2;
+use hyper_util::rt::{TokioExecutor, TokioIo};
 use hyper_util::server::graceful::GracefulShutdown;
 use std::net::TcpListener;
 use std::sync::Arc;
@@ -20,7 +21,10 @@ use crate::signals;
 
 use super::{ShutdownCtx, TlsConfig, redirect};
 
-/// Run the HTTP/2 + TLS accept loop with an optional HTTP → HTTPS redirect server.
+/// HTTP/2 graceful shutdown drain timeout in seconds.
+const HTTP2_DRAIN_TIMEOUT: u64 = 5;
+
+/// Run the HTTP/2 + TLS accept loop with an optional HTTP to HTTPS redirect server.
 pub(super) async fn run<F: FnOnce()>(
     tcp_listener: TcpListener,
     router: RouterService,
@@ -69,7 +73,7 @@ pub(super) async fn run<F: FnOnce()>(
     #[cfg(windows)]
     let redirect_ctrl_c_recv = ctrl_c_recv.clone();
 
-    // Optional HTTP → HTTPS redirect server
+    // Optional HTTP to HTTPS redirect server
     let redirect_task = redirect::maybe_spawn(
         &cfg,
         redirect_cancel_recv,
@@ -84,8 +88,7 @@ pub(super) async fn run<F: FnOnce()>(
         let router = router.clone();
         async move {
             let graceful = GracefulShutdown::new();
-            let builder =
-                hyper_util::server::conn::auto::Builder::new(hyper_util::rt::TokioExecutor::new());
+            let builder = http2::Builder::new(TokioExecutor::new());
 
             #[cfg(unix)]
             let shutdown = signals::wait_for_signals(signals, grace_period, cancel_recv);
@@ -116,16 +119,8 @@ pub(super) async fn run<F: FnOnce()>(
                         let svc = router.build(Some(addr));
                         match tls_acceptor.accept(stream).await {
                             Ok(tls_stream) => {
-                                let watcher = graceful.watcher();
-                                let builder_clone = builder.clone();
-                                tokio::spawn(async move {
-                                    let conn = builder_clone
-                                        .serve_connection(TokioIo::new(tls_stream), svc)
-                                        .into_owned();
-                                    if let Err(e) = watcher.watch(conn).await {
-                                        tracing::debug!("TLS connection error: {:?}", e);
-                                    }
-                                });
+                                let conn = builder.serve_connection(TokioIo::new(tls_stream), svc);
+                                tokio::spawn(graceful.watch(conn));
                             }
                             Err(e) => {
                                 tracing::debug!(
@@ -138,7 +133,23 @@ pub(super) async fn run<F: FnOnce()>(
                 }
             }
 
-            graceful.shutdown().await;
+            // HTTP/2 connections are persistent and clients may not close them
+            // promptly after receiving `GOAWAY`. Apply a fixed drain timeout so
+            // the server doesn't hang indefinitely waiting for idle connections.
+            // Specially on Windows due to its signal propagation as it sends
+            // a CTRL_C_EVENT only to processes attached to the same console.
+            if tokio::time::timeout(
+                std::time::Duration::from_secs(HTTP2_DRAIN_TIMEOUT),
+                graceful.shutdown(),
+            )
+            .await
+            .is_err()
+            {
+                tracing::warn!(
+                    "graceful shutdown drain timed out after {}s, forcing connection close",
+                    HTTP2_DRAIN_TIMEOUT
+                );
+            }
             Ok::<_, crate::Error>(())
         }
     });

--- a/src/server/http2.rs
+++ b/src/server/http2.rs
@@ -61,11 +61,13 @@ pub(super) async fn run<F: FnOnce()>(
     #[cfg(windows)]
     let redirect_cancel_recv = cancel_recv.clone();
     #[cfg(windows)]
-    let ctrl_c_recv = Arc::new(Mutex::new(Some(ctx.ctrl_c_recv)));
+    let ctrl_c_recv = Arc::new(Mutex::new(if !ctx.windows_service {
+        Some(ctx.ctrl_c_recv)
+    } else {
+        None
+    }));
     #[cfg(windows)]
     let redirect_ctrl_c_recv = ctrl_c_recv.clone();
-    #[cfg(windows)]
-    let windows_service = ctx.windows_service;
 
     // Optional HTTP → HTTPS redirect server
     let redirect_task = redirect::maybe_spawn(
@@ -73,8 +75,6 @@ pub(super) async fn run<F: FnOnce()>(
         redirect_cancel_recv,
         #[cfg(windows)]
         redirect_ctrl_c_recv,
-        #[cfg(windows)]
-        windows_service,
         grace_period,
     )?
     .unwrap_or_else(|| tokio::spawn(async { Ok::<_, crate::Error>(()) }));
@@ -94,11 +94,7 @@ pub(super) async fn run<F: FnOnce()>(
 
             #[cfg(windows)]
             let shutdown = async move {
-                if windows_service {
-                    signals::wait_for_ctrl_c(cancel_recv, grace_period).await;
-                } else {
-                    signals::wait_for_ctrl_c(ctrl_c_recv, grace_period).await;
-                }
+                signals::wait_for_ctrl_c_or_cancel(ctrl_c_recv, cancel_recv, grace_period).await;
             };
             #[cfg(windows)]
             tokio::pin!(shutdown);
@@ -113,7 +109,9 @@ pub(super) async fn run<F: FnOnce()>(
                                 continue;
                             }
                         };
-                        let _ = stream.set_nodelay(true);
+                        if let Err(e) = stream.set_nodelay(true) {
+                            tracing::warn!("failed to enable TCP_NODELAY for {}: {:?}", addr, e);
+                        }
                         let tls_acceptor = tls_acceptor.clone();
                         let svc = router.build(Some(addr));
                         match tls_acceptor.accept(stream).await {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -12,13 +12,43 @@ use tokio::sync::watch::Receiver;
 
 use crate::handler::RequestHandler;
 use crate::service::RouterService;
-use crate::{Context, Result, Settings};
+use crate::settings::cli::General;
+use crate::{Context, Error, Result, Settings};
 
 mod http1;
 mod opts;
 
+#[cfg(feature = "tls")]
+mod http1_tls;
 #[cfg(feature = "http2")]
 mod http2;
+#[cfg(feature = "tls")]
+mod redirect;
+
+/// TLS configuration shared by the HTTP/1+TLS and HTTP/2+TLS server modes.
+#[cfg(feature = "tls")]
+pub(crate) struct TlsConfig {
+    /// Path to the TLS certificate file.
+    pub tls_cert: std::path::PathBuf,
+    /// Path to the TLS private key file.
+    pub tls_key: std::path::PathBuf,
+    /// Enable HTTP → HTTPS redirect server.
+    pub https_redirect: bool,
+    /// Target hostname used in HTTPS redirect responses.
+    pub https_redirect_host: String,
+    /// Port the HTTP redirect server binds on.
+    pub https_redirect_from_port: u16,
+    /// Comma-separated list of hosts allowed to be redirected.
+    pub https_redirect_from_hosts: String,
+    /// Server host address (needed to bind the redirect listener).
+    pub host: String,
+    /// HTTPS port (used in redirect target URLs).
+    pub port: u16,
+    /// Resolved 404 error page (used by the redirect server).
+    pub page404: std::path::PathBuf,
+    /// Resolved 50x error page (used by the redirect server).
+    pub page50x: std::path::PathBuf,
+}
 
 /// Shutdown context passed to each server sub-module so they can respond to
 /// both OS signals and optional programmatic cancellation.
@@ -153,30 +183,7 @@ impl Server {
             );
         }
 
-        // Determine TCP listener: inherited file descriptor or bound TCP socket
-        let (tcp_listener, addr_str) = match general.fd {
-            Some(fd) => {
-                let listener = ListenFd::from_env()
-                    .take_tcp_listener(fd)?
-                    .with_context(|| "failed to convert inherited 'fd' into a 'tcp' listener")?;
-                tracing::info!(
-                    "converted inherited file descriptor {} to a 'tcp' listener",
-                    fd
-                );
-                (listener, format!("@FD({fd})"))
-            }
-            None => {
-                let ip = general
-                    .host
-                    .parse::<IpAddr>()
-                    .with_context(|| format!("failed to parse {} address", general.host))?;
-                let addr = SocketAddr::from((ip, general.port));
-                let listener = TcpListener::bind(addr)
-                    .with_context(|| format!("failed to bind to {addr} address"))?;
-                tracing::info!("server bound to tcp socket {}", addr);
-                (listener, addr.to_string())
-            }
-        };
+        let (tcp_listener, addr_str) = create_tcp_listener(&general)?;
 
         tracing::info!("runtime worker threads: {}", self.worker_threads);
         tracing::info!(
@@ -223,33 +230,58 @@ impl Server {
             ctrlc_task,
         };
 
-        // Dispatch to the HTTP/2 + TLS server when enabled
-        #[cfg(feature = "http2")]
-        if general.http2 {
-            return http2::run(
+        // Dispatch to a TLS-enabled server (HTTP/1+TLS or HTTP/2+TLS) when --tls is set
+        #[cfg(feature = "tls")]
+        if general.tls {
+            let tls_cert = general
+                .tls_cert
+                .ok_or_else(|| anyhow!("TLS cert file path is required when --tls is enabled"))?;
+            let tls_key = general
+                .tls_key
+                .ok_or_else(|| anyhow!("TLS key file path is required when --tls is enabled"))?;
+
+            let tls_cfg = TlsConfig {
+                tls_cert,
+                tls_key,
+                https_redirect: general.https_redirect,
+                https_redirect_host: general.https_redirect_host,
+                https_redirect_from_port: general.https_redirect_from_port,
+                https_redirect_from_hosts: general.https_redirect_from_hosts,
+                host: general.host,
+                port: general.port,
+                page404: opts_result.page404,
+                page50x: opts_result.page50x,
+            };
+
+            // If HTTP/2 is also enabled, use the HTTP/2+TLS accept loop
+            #[cfg(feature = "http2")]
+            if general.http2 {
+                return http2::run(
+                    tcp_listener,
+                    router_service,
+                    &addr_str,
+                    self.worker_threads,
+                    tls_cfg,
+                    ctx,
+                    cancel_fn,
+                )
+                .await;
+            }
+
+            // Otherwise serve HTTP/1 over TLS
+            return http1_tls::run(
                 tcp_listener,
                 router_service,
                 &addr_str,
                 self.worker_threads,
-                http2::Http2Config {
-                    tls_cert: general.http2_tls_cert,
-                    tls_key: general.http2_tls_key,
-                    https_redirect: general.https_redirect,
-                    https_redirect_host: general.https_redirect_host,
-                    https_redirect_from_port: general.https_redirect_from_port,
-                    https_redirect_from_hosts: general.https_redirect_from_hosts,
-                    host: general.host,
-                    port: general.port,
-                    page404: opts_result.page404,
-                    page50x: opts_result.page50x,
-                },
+                tls_cfg,
                 ctx,
                 cancel_fn,
             )
             .await;
         }
 
-        // Fall back to the plain HTTP/1 server
+        // Plain HTTP/1 (no TLS by default)
         http1::run(
             tcp_listener,
             router_service,
@@ -260,4 +292,31 @@ impl Server {
         )
         .await
     }
+}
+
+fn create_tcp_listener(general: &General) -> Result<(TcpListener, String), Error> {
+    let (listener, bound_addr) = match general.fd {
+        Some(fd) => {
+            let listener = ListenFd::from_env()
+                .take_tcp_listener(fd)?
+                .with_context(|| "failed to convert inherited 'fd' into a 'tcp' listener")?;
+            tracing::info!(
+                "converted inherited file descriptor {} to a 'tcp' listener",
+                fd
+            );
+            (listener, format!("@FD({fd})"))
+        }
+        None => {
+            let ip = general
+                .host
+                .parse::<IpAddr>()
+                .with_context(|| format!("failed to parse {} address", general.host))?;
+            let addr = SocketAddr::from((ip, general.port));
+            let listener = TcpListener::bind(addr)
+                .with_context(|| format!("failed to bind to {addr} address"))?;
+            tracing::info!("server bound to tcp socket {}", addr);
+            (listener, addr.to_string())
+        }
+    };
+    Ok((listener, bound_addr))
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -32,7 +32,7 @@ pub(crate) struct TlsConfig {
     pub tls_cert: std::path::PathBuf,
     /// Path to the TLS private key file.
     pub tls_key: std::path::PathBuf,
-    /// Enable HTTP → HTTPS redirect server.
+    /// Enable HTTP to HTTPS redirect server.
     pub https_redirect: bool,
     /// Target hostname used in HTTPS redirect responses.
     pub https_redirect_host: String,

--- a/src/server/opts.rs
+++ b/src/server/opts.rs
@@ -45,10 +45,10 @@ pub(super) struct HandlerOptsResult {
     /// Fully initialized request handler options.
     pub handler_opts: RequestHandlerOpts,
     /// Resolved 404 error page path (needed by the HTTPS redirect server).
-    #[cfg(feature = "http2")]
+    #[cfg(feature = "tls")]
     pub page404: std::path::PathBuf,
     /// Resolved 50x error page path (needed by the HTTPS redirect server).
-    #[cfg(feature = "http2")]
+    #[cfg(feature = "tls")]
     pub page50x: std::path::PathBuf,
 }
 
@@ -199,9 +199,9 @@ pub(super) fn init(general: &General, advanced: Option<Advanced>) -> Result<Hand
 
     Ok(HandlerOptsResult {
         handler_opts,
-        #[cfg(feature = "http2")]
+        #[cfg(feature = "tls")]
         page404,
-        #[cfg(feature = "http2")]
+        #[cfg(feature = "tls")]
         page50x,
     })
 }

--- a/src/server/redirect.rs
+++ b/src/server/redirect.rs
@@ -32,11 +32,8 @@ pub(super) struct RedirectConfig {
     /// Programmatic cancel receiver shared with the main TLS server.
     pub cancel_recv: Arc<Mutex<Option<Receiver<()>>>>,
     #[cfg(windows)]
-    /// Ctrl+C receiver (used when not running as a Windows service).
+    /// Ctrl+C receiver (used when not running as a Windows service; `None` in service mode).
     pub ctrl_c_recv: Arc<Mutex<Option<Receiver<()>>>>,
-    #[cfg(windows)]
-    /// Whether running as a Windows service.
-    pub windows_service: bool,
 }
 
 /// Spawn the HTTP → HTTPS redirect server task.
@@ -74,14 +71,8 @@ pub(super) fn spawn(
         #[cfg(windows)]
         let ctrl_c_recv = cfg.ctrl_c_recv;
         #[cfg(windows)]
-        let windows_service = cfg.windows_service;
-        #[cfg(windows)]
         let shutdown = async move {
-            if windows_service {
-                signals::wait_for_ctrl_c(cancel_recv, grace_period).await;
-            } else {
-                signals::wait_for_ctrl_c(ctrl_c_recv, grace_period).await;
-            }
+            signals::wait_for_ctrl_c_or_cancel(ctrl_c_recv, cancel_recv, grace_period).await;
         };
         #[cfg(windows)]
         tokio::pin!(shutdown);
@@ -89,7 +80,7 @@ pub(super) fn spawn(
         loop {
             tokio::select! {
                 result = redirect_listener.accept() => {
-                    let (stream, _addr) = match result {
+                    let (stream, addr) = match result {
                         Ok(v) => v,
                         Err(e) => {
                             tracing::error!(
@@ -98,7 +89,9 @@ pub(super) fn spawn(
                             continue;
                         }
                     };
-                    let _ = stream.set_nodelay(true);
+                    if let Err(e) = stream.set_nodelay(true) {
+                        tracing::warn!("failed to enable TCP_NODELAY for {}: {:?}", addr, e);
+                    }
                     let redirect_opts = cfg.opts.clone();
                     let page404 = cfg.page404.clone();
                     let page50x = cfg.page50x.clone();
@@ -142,7 +135,6 @@ pub(super) fn maybe_spawn(
     cfg: &super::TlsConfig,
     cancel_recv: Arc<Mutex<Option<Receiver<()>>>>,
     #[cfg(windows)] ctrl_c_recv: Arc<Mutex<Option<Receiver<()>>>>,
-    #[cfg(windows)] windows_service: bool,
     grace_period: u8,
 ) -> Result<Option<tokio::task::JoinHandle<crate::Result<()>>>> {
     if !cfg.https_redirect {
@@ -186,8 +178,6 @@ pub(super) fn maybe_spawn(
             cancel_recv,
             #[cfg(windows)]
             ctrl_c_recv,
-            #[cfg(windows)]
-            windows_service,
         },
     )?;
 

--- a/src/server/redirect.rs
+++ b/src/server/redirect.rs
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// This file is part of Static Web Server.
+// See https://static-web-server.net/ for more information
+// Copyright (C) 2019-present Jose Quintana <joseluisq.net>
+
+//! Shared HTTP to HTTPS redirect server used by both the HTTP/1+TLS and HTTP/2+TLS modes.
+
+use hyper::server::conn::http1;
+use hyper_util::rt::TokioIo;
+use hyper_util::server::graceful::GracefulShutdown;
+use std::net::{SocketAddr, TcpListener};
+use std::path::PathBuf;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+use tokio::sync::watch::Receiver;
+
+use crate::{Context, Result, error_page, https_redirect};
+
+#[cfg(any(unix, windows))]
+use crate::signals;
+
+/// Configuration for the HTTP → HTTPS redirect server.
+pub(super) struct RedirectConfig {
+    /// Resolved redirect options (hostname, port, allowed hosts).
+    pub opts: Arc<https_redirect::RedirectOpts>,
+    /// Resolved 404 error page path.
+    pub page404: PathBuf,
+    /// Resolved 50x error page path.
+    pub page50x: PathBuf,
+    /// Grace period in seconds.
+    pub grace_period: u8,
+    /// Programmatic cancel receiver shared with the main TLS server.
+    pub cancel_recv: Arc<Mutex<Option<Receiver<()>>>>,
+    #[cfg(windows)]
+    /// Ctrl+C receiver (used when not running as a Windows service).
+    pub ctrl_c_recv: Arc<Mutex<Option<Receiver<()>>>>,
+    #[cfg(windows)]
+    /// Whether running as a Windows service.
+    pub windows_service: bool,
+}
+
+/// Spawn the HTTP → HTTPS redirect server task.
+///
+/// Returns a [`JoinHandle`] that resolves once the server shuts down. The
+/// caller should `tokio::try_join!` it together with the main TLS server task.
+pub(super) fn spawn(
+    tcp_listener: TcpListener,
+    cfg: RedirectConfig,
+) -> Result<tokio::task::JoinHandle<crate::Result<()>>> {
+    tcp_listener
+        .set_nonblocking(true)
+        .with_context(|| "failed to set TCP non-blocking mode for redirect listener")?;
+
+    #[cfg(unix)]
+    let redirect_signals =
+        signals::create_signals().with_context(|| "failed to register termination signals")?;
+    #[cfg(unix)]
+    let redirect_handle = redirect_signals.handle();
+
+    let handle = tokio::spawn(async move {
+        let redirect_listener = tokio::net::TcpListener::from_std(tcp_listener)
+            .with_context(|| "failed to create redirect TcpListener")?;
+        let graceful = GracefulShutdown::new();
+        let http = http1::Builder::new();
+
+        let grace_period = cfg.grace_period;
+        let cancel_recv = cfg.cancel_recv;
+
+        #[cfg(unix)]
+        let shutdown = signals::wait_for_signals(redirect_signals, grace_period, cancel_recv);
+        #[cfg(unix)]
+        tokio::pin!(shutdown);
+
+        #[cfg(windows)]
+        let ctrl_c_recv = cfg.ctrl_c_recv;
+        #[cfg(windows)]
+        let windows_service = cfg.windows_service;
+        #[cfg(windows)]
+        let shutdown = async move {
+            if windows_service {
+                signals::wait_for_ctrl_c(cancel_recv, grace_period).await;
+            } else {
+                signals::wait_for_ctrl_c(ctrl_c_recv, grace_period).await;
+            }
+        };
+        #[cfg(windows)]
+        tokio::pin!(shutdown);
+
+        loop {
+            tokio::select! {
+                result = redirect_listener.accept() => {
+                    let (stream, _addr) = match result {
+                        Ok(v) => v,
+                        Err(e) => {
+                            tracing::error!(
+                                "failed to accept redirect TCP connection: {:?}", e
+                            );
+                            continue;
+                        }
+                    };
+                    let _ = stream.set_nodelay(true);
+                    let redirect_opts = cfg.opts.clone();
+                    let page404 = cfg.page404.clone();
+                    let page50x = cfg.page50x.clone();
+                    let svc = hyper::service::service_fn(move |req| {
+                        let redirect_opts = redirect_opts.clone();
+                        let page404 = page404.clone();
+                        let page50x = page50x.clone();
+                        async move {
+                            let uri = req.uri().clone();
+                            let method = req.method().clone();
+                            match https_redirect::redirect_to_https(&req, redirect_opts) {
+                                Ok(resp) => Ok(resp),
+                                Err(status) => error_page::error_response(
+                                    &uri, &method, &status, &page404, &page50x,
+                                ),
+                            }
+                        }
+                    });
+                    let conn = http.serve_connection(TokioIo::new(stream), svc);
+                    tokio::spawn(graceful.watch(conn));
+                }
+                _ = &mut shutdown => { break; }
+            }
+        }
+
+        graceful.shutdown().await;
+
+        #[cfg(unix)]
+        redirect_handle.close();
+
+        Ok::<_, crate::Error>(())
+    });
+
+    Ok(handle)
+}
+
+/// Build [`RedirectOpts`] and bind the redirect TCP listener from a [`super::TlsConfig`].
+///
+/// Returns `None` when HTTPS redirect is disabled in the configuration.
+pub(super) fn maybe_spawn(
+    cfg: &super::TlsConfig,
+    cancel_recv: Arc<Mutex<Option<Receiver<()>>>>,
+    #[cfg(windows)] ctrl_c_recv: Arc<Mutex<Option<Receiver<()>>>>,
+    #[cfg(windows)] windows_service: bool,
+    grace_period: u8,
+) -> Result<Option<tokio::task::JoinHandle<crate::Result<()>>>> {
+    if !cfg.https_redirect {
+        return Ok(None);
+    }
+
+    let addr = SocketAddr::new(
+        cfg.host
+            .parse()
+            .with_context(|| format!("failed to parse {} as IP address", cfg.host))?,
+        cfg.https_redirect_from_port,
+    );
+
+    let tcp_listener = TcpListener::bind(addr)
+        .with_context(|| format!("failed to bind redirect listener to {addr}"))?;
+
+    tracing::info!("http1 redirect server is listening on http://{}", addr);
+
+    let allowed_hosts = cfg
+        .https_redirect_from_hosts
+        .split(',')
+        .map(|s| s.trim().to_owned())
+        .collect::<Vec<_>>();
+    if allowed_hosts.is_empty() {
+        bail!("https redirect allowed hosts is empty, provide at least one host or IP");
+    }
+
+    let redirect_opts = Arc::new(https_redirect::RedirectOpts {
+        https_hostname: cfg.https_redirect_host.clone(),
+        https_port: cfg.port,
+        allowed_hosts,
+    });
+
+    let task = spawn(
+        tcp_listener,
+        RedirectConfig {
+            opts: redirect_opts,
+            page404: cfg.page404.clone(),
+            page50x: cfg.page50x.clone(),
+            grace_period,
+            cancel_recv,
+            #[cfg(windows)]
+            ctrl_c_recv,
+            #[cfg(windows)]
+            windows_service,
+        },
+    )?;
+
+    Ok(Some(task))
+}

--- a/src/server/redirect.rs
+++ b/src/server/redirect.rs
@@ -19,7 +19,7 @@ use crate::{Context, Result, error_page, https_redirect};
 #[cfg(any(unix, windows))]
 use crate::signals;
 
-/// Configuration for the HTTP → HTTPS redirect server.
+/// Configuration for the HTTP to HTTPS redirect server.
 pub(super) struct RedirectConfig {
     /// Resolved redirect options (hostname, port, allowed hosts).
     pub opts: Arc<https_redirect::RedirectOpts>,
@@ -36,7 +36,7 @@ pub(super) struct RedirectConfig {
     pub ctrl_c_recv: Arc<Mutex<Option<Receiver<()>>>>,
 }
 
-/// Spawn the HTTP → HTTPS redirect server task.
+/// Spawn the HTTP to HTTPS redirect server task.
 ///
 /// Returns a [`JoinHandle`] that resolves once the server shuts down. The
 /// caller should `tokio::try_join!` it together with the main TLS server task.

--- a/src/settings/cli.rs
+++ b/src/settings/cli.rs
@@ -30,7 +30,7 @@ pub struct General {
     pub port: u16,
 
     #[cfg_attr(
-        feature = "http2",
+        feature = "tls",
         arg(
             long,
             short = 'f',
@@ -39,7 +39,7 @@ pub struct General {
         )
     )]
     #[cfg_attr(
-        not(feature = "http2"),
+        not(feature = "tls"),
         arg(
             long,
             short = 'f',
@@ -173,24 +173,24 @@ pub struct General {
         num_args(0..=1),
         require_equals(false),
         action = clap::ArgAction::Set,
-        env = "SERVER_HTTP2_TLS",
+        env = "SERVER_TLS",
     )]
-    #[cfg(feature = "http2")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "http2")))]
-    /// Enable HTTP/2 with TLS support.
-    pub http2: bool,
+    #[cfg(feature = "tls")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "tls")))]
+    /// Enable TLS/HTTPS support. Requires --tls-cert and --tls-key.
+    pub tls: bool,
 
-    #[arg(long, required_if_eq("http2", "true"), env = "SERVER_HTTP2_TLS_CERT")]
-    #[cfg(feature = "http2")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "http2")))]
-    /// Specify the file path to read the certificate.
-    pub http2_tls_cert: Option<PathBuf>,
+    #[arg(long, required_if_eq("tls", "true"), env = "SERVER_TLS_CERT")]
+    #[cfg(feature = "tls")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "tls")))]
+    /// Specify the file path to the TLS certificate.
+    pub tls_cert: Option<PathBuf>,
 
-    #[arg(long, required_if_eq("http2", "true"), env = "SERVER_HTTP2_TLS_KEY")]
-    #[cfg(feature = "http2")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "http2")))]
-    /// Specify the file path to read the private key.
-    pub http2_tls_key: Option<PathBuf>,
+    #[arg(long, required_if_eq("tls", "true"), env = "SERVER_TLS_KEY")]
+    #[cfg(feature = "tls")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "tls")))]
+    /// Specify the file path to the TLS private key.
+    pub tls_key: Option<PathBuf>,
 
     #[arg(
         long,
@@ -199,44 +199,46 @@ pub struct General {
         num_args(0..=1),
         require_equals(false),
         action = clap::ArgAction::Set,
-        requires_if("true", "http2"),
+        env = "SERVER_HTTP2",
+    )]
+    #[cfg(feature = "http2")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "http2")))]
+    /// Enable HTTP/2 protocol support. Requires TLS to be enabled (--tls).
+    pub http2: bool,
+
+    #[arg(
+        long,
+        default_value = "false",
+        default_missing_value("true"),
+        num_args(0..=1),
+        require_equals(false),
+        action = clap::ArgAction::Set,
         env = "SERVER_HTTPS_REDIRECT"
     )]
-    #[cfg(feature = "http2")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "http2")))]
-    /// Redirect all requests with scheme "http" to "https" for the current server instance. It depends on "http2" to be enabled.
+    #[cfg(feature = "tls")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "tls")))]
+    /// Redirect all requests with scheme "http" to "https" for the current server instance. Requires TLS to be enabled (--tls).
     pub https_redirect: bool,
 
-    #[arg(
-        long,
-        requires_if("true", "https_redirect"),
-        default_value = "localhost",
-        env = "SERVER_HTTPS_REDIRECT_HOST"
-    )]
-    #[cfg(feature = "http2")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "http2")))]
-    /// Canonical host name or IP of the HTTPS (HTTPS/2) server. It depends on "https_redirect" to be enabled.
+    #[arg(long, default_value = "localhost", env = "SERVER_HTTPS_REDIRECT_HOST")]
+    #[cfg(feature = "tls")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "tls")))]
+    /// Canonical host name or IP of the HTTPS server. It depends on "https_redirect" to be enabled.
     pub https_redirect_host: String,
 
-    #[arg(
-        long,
-        requires_if("true", "https_redirect"),
-        default_value = "80",
-        env = "SERVER_HTTPS_REDIRECT_FROM_PORT"
-    )]
-    #[cfg(feature = "http2")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "http2")))]
+    #[arg(long, default_value = "80", env = "SERVER_HTTPS_REDIRECT_FROM_PORT")]
+    #[cfg(feature = "tls")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "tls")))]
     /// HTTP host port where the redirect server will listen for requests to redirect them to HTTPS. It depends on "https_redirect" to be enabled.
     pub https_redirect_from_port: u16,
 
     #[arg(
         long,
-        requires_if("true", "https_redirect"),
         default_value = "localhost",
         env = "SERVER_HTTPS_REDIRECT_FROM_HOSTS"
     )]
-    #[cfg(feature = "http2")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "http2")))]
+    #[cfg(feature = "tls")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "tls")))]
     /// List of host names or IPs allowed to redirect from. HTTP requests must contain the HTTP 'Host' header and match against this list. It depends on "https_redirect" to be enabled.
     pub https_redirect_from_hosts: String,
 
@@ -365,17 +367,32 @@ pub struct General {
     /// Specify list of enabled format(s) for directory download. Format supported: `targz`. Default to empty list (disabled).
     pub directory_listing_download: Vec<DirDownloadFmt>,
 
-    #[arg(
-        long,
-        default_value = "false",
-        default_value_if("http2", "true", Some("true")),
-        default_missing_value("true"),
-        num_args(0..=1),
-        require_equals(false),
-        action = clap::ArgAction::Set,
-        env = "SERVER_SECURITY_HEADERS",
+    #[cfg_attr(
+        feature = "tls",
+        arg(
+            long,
+            default_value = "false",
+            default_missing_value("true"),
+            num_args(0..=1),
+            require_equals(false),
+            action = clap::ArgAction::Set,
+            default_value_if("tls", "true", Some("true")),
+            env = "SERVER_SECURITY_HEADERS",
+        )
     )]
-    /// Enable security headers by default when HTTP/2 feature is activated.
+    #[cfg_attr(
+        not(feature = "tls"),
+        arg(
+            long,
+            default_value = "false",
+            default_missing_value("true"),
+            num_args(0..=1),
+            require_equals(false),
+            action = clap::ArgAction::Set,
+            env = "SERVER_SECURITY_HEADERS",
+        )
+    )]
+    /// Enable security headers by default when TLS feature is activated.
     /// Headers included: "Strict-Transport-Security: max-age=63072000; includeSubDomains; preload" (2 years max-age),
     /// "X-Frame-Options: DENY" and "Content-Security-Policy: frame-ancestors 'self'".
     pub security_headers: bool,

--- a/src/settings/file.rs
+++ b/src/settings/file.rs
@@ -264,34 +264,39 @@ pub struct General {
     /// Error 50x pages.
     pub page50x: Option<PathBuf>,
 
-    /// HTTP/2 + TLS.
+    /// TLS support.
+    #[cfg(feature = "tls")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "tls")))]
+    pub tls: Option<bool>,
+    /// TLS certificate file path.
+    #[cfg(feature = "tls")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "tls")))]
+    pub tls_cert: Option<PathBuf>,
+    /// TLS private key file path.
+    #[cfg(feature = "tls")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "tls")))]
+    pub tls_key: Option<PathBuf>,
+
+    /// HTTP/2 protocol support.
     #[cfg(feature = "http2")]
     #[cfg_attr(docsrs, doc(cfg(feature = "http2")))]
     pub http2: Option<bool>,
-    /// Http2 tls certificate feature.
-    #[cfg(feature = "http2")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "http2")))]
-    pub http2_tls_cert: Option<PathBuf>,
-    /// Http2 tls key feature.
-    #[cfg(feature = "http2")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "http2")))]
-    pub http2_tls_key: Option<PathBuf>,
 
     /// Redirect all HTTP requests to HTTPS.
-    #[cfg(feature = "http2")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "http2")))]
+    #[cfg(feature = "tls")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "tls")))]
     pub https_redirect: Option<bool>,
-    /// HTTP host port where the redirect server will listen for requests to redirect them to HTTPS.
-    #[cfg(feature = "http2")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "http2")))]
+    /// Hostname used in HTTPS redirect responses.
+    #[cfg(feature = "tls")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "tls")))]
     pub https_redirect_host: Option<String>,
-    /// Host port for redirecting HTTP requests to HTTPS.
-    #[cfg(feature = "http2")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "http2")))]
+    /// Port the HTTP redirect listener binds to.
+    #[cfg(feature = "tls")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "tls")))]
     pub https_redirect_from_port: Option<u16>,
     /// List of host names or IPs allowed to redirect from.
-    #[cfg(feature = "http2")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "http2")))]
+    #[cfg(feature = "tls")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "tls")))]
     pub https_redirect_from_hosts: Option<String>,
 
     /// Security headers.

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -152,20 +152,22 @@ impl Settings {
         let mut page404 = opts.page404;
         let mut page50x = opts.page50x;
 
+        #[cfg(feature = "tls")]
+        let mut tls = opts.tls;
+        #[cfg(feature = "tls")]
+        let mut tls_cert = opts.tls_cert;
+        #[cfg(feature = "tls")]
+        let mut tls_key = opts.tls_key;
+        #[cfg(feature = "tls")]
+        let mut https_redirect = opts.https_redirect;
+        #[cfg(feature = "tls")]
+        let mut https_redirect_host = opts.https_redirect_host;
+        #[cfg(feature = "tls")]
+        let mut https_redirect_from_port = opts.https_redirect_from_port;
+        #[cfg(feature = "tls")]
+        let mut https_redirect_from_hosts = opts.https_redirect_from_hosts;
         #[cfg(feature = "http2")]
         let mut http2 = opts.http2;
-        #[cfg(feature = "http2")]
-        let mut http2_tls_cert = opts.http2_tls_cert;
-        #[cfg(feature = "http2")]
-        let mut http2_tls_key = opts.http2_tls_key;
-        #[cfg(feature = "http2")]
-        let mut https_redirect = opts.https_redirect;
-        #[cfg(feature = "http2")]
-        let mut https_redirect_host = opts.https_redirect_host;
-        #[cfg(feature = "http2")]
-        let mut https_redirect_from_port = opts.https_redirect_from_port;
-        #[cfg(feature = "http2")]
-        let mut https_redirect_from_hosts = opts.https_redirect_from_hosts;
 
         let mut security_headers = opts.security_headers;
         let mut cors_allow_origins = opts.cors_allow_origins;
@@ -283,44 +285,48 @@ impl Settings {
                 if let Some(v) = general.page50x {
                     page50x = v
                 }
+                #[cfg(feature = "tls")]
+                if let Some(v) = general.tls {
+                    tls = v
+                }
+                #[cfg(feature = "tls")]
+                if let Some(v) = general.tls_cert {
+                    tls_cert = Some(v)
+                }
+                #[cfg(feature = "tls")]
+                if let Some(v) = general.tls_key {
+                    tls_key = Some(v)
+                }
                 #[cfg(feature = "http2")]
                 if let Some(v) = general.http2 {
                     http2 = v
                 }
-                #[cfg(feature = "http2")]
-                if let Some(v) = general.http2_tls_cert {
-                    http2_tls_cert = Some(v)
-                }
-                #[cfg(feature = "http2")]
-                if let Some(v) = general.http2_tls_key {
-                    http2_tls_key = Some(v)
-                }
-                #[cfg(feature = "http2")]
+                #[cfg(feature = "tls")]
                 if let Some(v) = general.https_redirect {
                     https_redirect = v
                 }
-                #[cfg(feature = "http2")]
+                #[cfg(feature = "tls")]
                 if let Some(v) = general.https_redirect_host {
                     https_redirect_host = v
                 }
-                #[cfg(feature = "http2")]
+                #[cfg(feature = "tls")]
                 if let Some(v) = general.https_redirect_from_port {
                     https_redirect_from_port = v
                 }
-                #[cfg(feature = "http2")]
+                #[cfg(feature = "tls")]
                 if let Some(v) = general.https_redirect_from_hosts {
                     https_redirect_from_hosts = v
                 }
-                #[cfg(feature = "http2")]
+                #[cfg(feature = "tls")]
                 match general.security_headers {
                     Some(v) => security_headers = v,
                     _ => {
-                        if http2 {
+                        if tls {
                             security_headers = true;
                         }
                     }
                 }
-                #[cfg(not(feature = "http2"))]
+                #[cfg(not(feature = "tls"))]
                 if let Some(v) = general.security_headers {
                     security_headers = v
                 }
@@ -608,6 +614,24 @@ impl Settings {
             logger::init(log_level.as_str(), log_with_ansi)?;
         }
 
+        // Runtime validation: HTTP/2 requires TLS
+        #[cfg(all(feature = "http2", feature = "tls"))]
+        if http2 && !tls {
+            bail!("HTTP/2 requires TLS; enable --tls along with --tls-cert and --tls-key");
+        }
+
+        // Runtime validation: HTTPS redirect requires TLS
+        #[cfg(feature = "tls")]
+        if https_redirect && !tls {
+            bail!("--https-redirect requires TLS to be enabled (--tls)");
+        }
+
+        // Auto-enable security headers when TLS is on (applies when no config file is present)
+        #[cfg(feature = "tls")]
+        if tls && !security_headers {
+            security_headers = true;
+        }
+
         Ok(Settings {
             general: General {
                 version,
@@ -639,17 +663,19 @@ impl Settings {
                 page50x,
                 #[cfg(feature = "http2")]
                 http2,
-                #[cfg(feature = "http2")]
-                http2_tls_cert,
-                #[cfg(feature = "http2")]
-                http2_tls_key,
-                #[cfg(feature = "http2")]
+                #[cfg(feature = "tls")]
+                tls,
+                #[cfg(feature = "tls")]
+                tls_cert,
+                #[cfg(feature = "tls")]
+                tls_key,
+                #[cfg(feature = "tls")]
                 https_redirect,
-                #[cfg(feature = "http2")]
+                #[cfg(feature = "tls")]
                 https_redirect_host,
-                #[cfg(feature = "http2")]
+                #[cfg(feature = "tls")]
                 https_redirect_from_port,
-                #[cfg(feature = "http2")]
+                #[cfg(feature = "tls")]
                 https_redirect_from_hosts,
                 security_headers,
                 cors_allow_origins,

--- a/src/signals.rs
+++ b/src/signals.rs
@@ -90,3 +90,37 @@ pub async fn wait_for_ctrl_c(cancel_recv: Arc<Mutex<Option<Receiver<()>>>>, grac
     delay_graceful_shutdown(grace_period_secs).await;
     tracing::info!("delegating server's graceful shutdown");
 }
+
+#[cfg(windows)]
+#[cfg_attr(docsrs, doc(cfg(windows)))]
+/// Waits for the first of `ctrl_c_recv` (real Ctrl+C) or `cancel_recv`
+/// (programmatic shutdown) to fire.
+///
+/// Pass `None` inside either `Arc<Mutex<Option<…>>>` to disable that source;
+/// the other source then becomes the sole shutdown trigger.
+pub async fn wait_for_ctrl_c_or_cancel(
+    ctrl_c_recv: Arc<Mutex<Option<Receiver<()>>>>,
+    cancel_recv: Arc<Mutex<Option<Receiver<()>>>>,
+    grace_period_secs: u8,
+) {
+    let (tx, mut rx) = tokio::sync::mpsc::channel::<()>(1);
+
+    let tx1 = tx.clone();
+    tokio::spawn(async move {
+        if let Some(recv) = &mut *ctrl_c_recv.lock().await {
+            recv.changed().await.ok();
+            tx1.send(()).await.ok();
+        }
+    });
+
+    tokio::spawn(async move {
+        if let Some(recv) = &mut *cancel_recv.lock().await {
+            recv.changed().await.ok();
+            tx.send(()).await.ok();
+        }
+    });
+
+    rx.recv().await;
+    delay_graceful_shutdown(grace_period_secs).await;
+    tracing::info!("delegating server's graceful shutdown");
+}

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -363,4 +363,60 @@ mod tests {
             .build()
             .unwrap();
     }
+
+    #[test]
+    fn missing_cert_path_returns_io_error() {
+        let err = TlsConfigBuilder::new()
+            .cert_path("tests/tls/nonexistent_cert.pem")
+            .key_path("tests/tls/local.dev_key.pkcs8.pem")
+            .build()
+            .unwrap_err();
+        assert!(
+            matches!(err, TlsConfigError::CertParseError | TlsConfigError::Io(_)),
+            "expected Io or CertParseError, got: {err}"
+        );
+    }
+
+    #[test]
+    fn missing_key_path_returns_io_error() {
+        let err = TlsConfigBuilder::new()
+            .cert_path("tests/tls/local.dev_cert.pkcs8.pem")
+            .key_path("tests/tls/nonexistent_key.pem")
+            .build()
+            .unwrap_err();
+        assert!(
+            matches!(err, TlsConfigError::Io(_)),
+            "expected Io error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn empty_key_bytes_returns_empty_key_error() {
+        let cert = include_str!("../tests/tls/local.dev_cert.pkcs8.pem");
+        let err = TlsConfigBuilder::new()
+            .cert(cert.as_bytes())
+            .key(b"")
+            .build()
+            .unwrap_err();
+        assert!(
+            matches!(err, TlsConfigError::EmptyKey),
+            "expected EmptyKey error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn mismatched_cert_key_returns_invalid_key_error() {
+        // Use rsa_pkcs1 cert with ec key — should fail at the ServerConfig builder stage
+        let cert = include_str!("../tests/tls/local.dev_cert.rsa_pkcs1.pem");
+        let key = include_str!("../tests/tls/local.dev_key.sec1_ec.pem");
+        let err = TlsConfigBuilder::new()
+            .cert(cert.as_bytes())
+            .key(key.as_bytes())
+            .build()
+            .unwrap_err();
+        assert!(
+            matches!(err, TlsConfigError::InvalidKey(_)),
+            "expected InvalidKey error for mismatched cert/key, got: {err}"
+        );
+    }
 }

--- a/tests/tls.rs
+++ b/tests/tls.rs
@@ -1,0 +1,345 @@
+#![forbid(unsafe_code)]
+#![deny(warnings)]
+#![deny(rust_2018_idioms)]
+#![deny(dead_code)]
+
+/// Grab a free local port by briefly binding to 0 and reading back the
+/// OS-assigned port. The listener is immediately dropped so the port is
+/// available when the server binds to it.
+#[cfg(feature = "tls")]
+fn free_port() -> u16 {
+    std::net::TcpListener::bind("127.0.0.1:0")
+        .expect("failed to find a free port")
+        .local_addr()
+        .unwrap()
+        .port()
+}
+
+// Settings validation tests
+
+#[cfg(test)]
+mod settings_tests {
+    #[cfg(feature = "tls")]
+    const CERT: &str = "tests/tls/local.dev_cert.pkcs8.pem";
+    #[cfg(feature = "tls")]
+    const KEY: &str = "tests/tls/local.dev_key.pkcs8.pem";
+
+    /// `--tls`, `--tls-cert` and `--tls-key` must parse successfully and be
+    /// reflected in the resolved `General` settings.
+    #[cfg(feature = "tls")]
+    #[test]
+    fn tls_flags_parse_correctly() {
+        use std::path::PathBuf;
+
+        let settings = static_web_server::Settings::get_unparsed(
+            false,
+            &[
+                "static-web-server",
+                "--root",
+                "tests/fixtures/public",
+                "--port",
+                "0",
+                "--tls",
+                "--tls-cert",
+                CERT,
+                "--tls-key",
+                KEY,
+            ],
+        )
+        .expect("settings with --tls must parse");
+
+        assert!(settings.general.tls, "general.tls should be true");
+        assert_eq!(
+            settings.general.tls_cert,
+            Some(PathBuf::from(CERT)),
+            "tls_cert should be set"
+        );
+        assert_eq!(
+            settings.general.tls_key,
+            Some(PathBuf::from(KEY)),
+            "tls_key should be set"
+        );
+    }
+
+    /// Enabling TLS must automatically set `security_headers = true` even if
+    /// the user did not supply `--security-headers`.
+    #[cfg(feature = "tls")]
+    #[test]
+    fn tls_auto_enables_security_headers() {
+        let settings = static_web_server::Settings::get_unparsed(
+            false,
+            &[
+                "static-web-server",
+                "--root",
+                "tests/fixtures/public",
+                "--port",
+                "0",
+                "--tls",
+                "--tls-cert",
+                CERT,
+                "--tls-key",
+                KEY,
+            ],
+        )
+        .expect("settings with --tls must parse");
+
+        assert!(
+            settings.general.security_headers,
+            "--tls should automatically enable security_headers"
+        );
+    }
+
+    /// `--https-redirect` requires `--tls`; without it the settings parsing
+    /// must return an error containing the expected diagnostic message.
+    #[cfg(feature = "tls")]
+    #[test]
+    fn https_redirect_without_tls_fails() {
+        match static_web_server::Settings::get_unparsed(
+            false,
+            &[
+                "static-web-server",
+                "--root",
+                "tests/fixtures/public",
+                "--port",
+                "0",
+                "--https-redirect",
+            ],
+        ) {
+            Ok(_) => panic!("--https-redirect without --tls should have failed"),
+            Err(err) => assert!(
+                err.to_string().contains("--https-redirect requires TLS"),
+                "unexpected error message: {err}"
+            ),
+        }
+    }
+
+    /// `--http2` requires `--tls`; without it the settings parsing must fail.
+    #[cfg(all(feature = "tls", feature = "http2"))]
+    #[test]
+    fn http2_without_tls_fails() {
+        match static_web_server::Settings::get_unparsed(
+            false,
+            &[
+                "static-web-server",
+                "--root",
+                "tests/fixtures/public",
+                "--port",
+                "0",
+                "--http2",
+            ],
+        ) {
+            Ok(_) => panic!("--http2 without --tls should have failed"),
+            Err(err) => assert!(
+                err.to_string().contains("HTTP/2 requires TLS"),
+                "unexpected error message: {err}"
+            ),
+        }
+    }
+
+    /// `--http2` combined with `--tls` must parse successfully and both flags
+    /// must be reflected in the resolved settings.
+    #[cfg(all(feature = "tls", feature = "http2"))]
+    #[test]
+    fn http2_with_tls_parses_correctly() {
+        let settings = static_web_server::Settings::get_unparsed(
+            false,
+            &[
+                "static-web-server",
+                "--root",
+                "tests/fixtures/public",
+                "--port",
+                "0",
+                "--tls",
+                "--tls-cert",
+                CERT,
+                "--tls-key",
+                KEY,
+                "--http2",
+            ],
+        )
+        .expect("settings with --tls --http2 must parse");
+
+        assert!(settings.general.tls, "general.tls should be true");
+        assert!(settings.general.http2, "general.http2 should be true");
+    }
+}
+
+// Live server tests
+
+/// Live-server tests that spin up a real TLS listener, assert that TCP
+/// connections are accepted and then shut the server down via a cancel channel.
+#[cfg(feature = "tls")]
+#[cfg(test)]
+mod live_server_tests {
+    use super::free_port;
+    use static_web_server::{Server, Settings};
+    use std::time::Duration;
+
+    const CERT: &str = "tests/tls/local.dev_cert.pkcs8.pem";
+    const KEY: &str = "tests/tls/local.dev_key.pkcs8.pem";
+
+    /// Start an HTTP/1+TLS server on a free port, verify that a raw TCP
+    /// connection is accepted (proving the listener is up), then cancel the
+    /// server and confirm it exits cleanly.
+    #[test]
+    fn http1_tls_server_starts_and_accepts_connections() {
+        let port = free_port();
+
+        let (cancel_tx, cancel_rx) = tokio::sync::watch::channel(());
+
+        let port_str = port.to_string();
+        let server_thread = std::thread::spawn(move || {
+            let settings = Settings::get_unparsed(
+                false,
+                &[
+                    "static-web-server",
+                    "--root",
+                    "tests/fixtures/public",
+                    "--host",
+                    "127.0.0.1",
+                    "--port",
+                    &port_str,
+                    "--tls",
+                    "--tls-cert",
+                    CERT,
+                    "--tls-key",
+                    KEY,
+                ],
+            )
+            .expect("settings must parse");
+
+            Server::new(settings)
+                .expect("server must build")
+                .run_server_on_rt(Some(cancel_rx), || {}, false)
+        });
+
+        // Allow the server time to bind and start its accept loop.
+        std::thread::sleep(Duration::from_millis(300));
+
+        // A successful TCP connect proves the server is listening.
+        std::net::TcpStream::connect(format!("127.0.0.1:{port}"))
+            .expect("TLS server should accept TCP connections");
+
+        // Signal a graceful shutdown.
+        cancel_tx.send(()).expect("cancel signal must be sent");
+
+        let result = server_thread
+            .join()
+            .expect("server thread should not panic");
+        assert!(
+            result.is_ok(),
+            "server should shut down cleanly, got: {:?}",
+            result
+        );
+    }
+
+    /// Starting a TLS server with a cert/key pair of a different algorithm
+    /// (e.g. RSA cert with EC key) must fail before accepting any connections.
+    #[test]
+    fn http1_tls_server_mismatched_cert_key_fails_to_start() {
+        let port = free_port();
+
+        let (_, cancel_rx) = tokio::sync::watch::channel(());
+
+        let port_str = port.to_string();
+        let result = std::thread::spawn(move || {
+            let settings = Settings::get_unparsed(
+                false,
+                &[
+                    "static-web-server",
+                    "--root",
+                    "tests/fixtures/public",
+                    "--host",
+                    "127.0.0.1",
+                    "--port",
+                    &port_str,
+                    "--tls",
+                    "--tls-cert",
+                    "tests/tls/local.dev_cert.rsa_pkcs1.pem",
+                    "--tls-key",
+                    "tests/tls/local.dev_key.sec1_ec.pem",
+                ],
+            )
+            .expect("settings must parse");
+
+            Server::new(settings)
+                .expect("server must build")
+                .run_server_on_rt(Some(cancel_rx), || {}, false)
+        })
+        .join()
+        .expect("thread should not panic");
+
+        assert!(
+            result.is_err(),
+            "server with mismatched cert/key should fail to start"
+        );
+    }
+}
+
+/// Live HTTP/2+TLS server tests.
+#[cfg(all(feature = "tls", feature = "http2"))]
+#[cfg(test)]
+mod live_http2_server_tests {
+    use super::free_port;
+    use static_web_server::{Server, Settings};
+    use std::time::Duration;
+
+    const CERT: &str = "tests/tls/local.dev_cert.pkcs8.pem";
+    const KEY: &str = "tests/tls/local.dev_key.pkcs8.pem";
+
+    /// Start an HTTP/2+TLS server on a free port, verify that a raw TCP
+    /// connection is accepted (proving the listener is up), then cancel the
+    /// server and confirm it exits cleanly.
+    #[test]
+    fn http2_tls_server_starts_and_accepts_connections() {
+        let port = free_port();
+
+        let (cancel_tx, cancel_rx) = tokio::sync::watch::channel(());
+
+        let port_str = port.to_string();
+        let server_thread = std::thread::spawn(move || {
+            let settings = Settings::get_unparsed(
+                false,
+                &[
+                    "static-web-server",
+                    "--root",
+                    "tests/fixtures/public",
+                    "--host",
+                    "127.0.0.1",
+                    "--port",
+                    &port_str,
+                    "--tls",
+                    "--tls-cert",
+                    CERT,
+                    "--tls-key",
+                    KEY,
+                    "--http2",
+                ],
+            )
+            .expect("settings must parse");
+
+            Server::new(settings)
+                .expect("server must build")
+                .run_server_on_rt(Some(cancel_rx), || {}, false)
+        });
+
+        // Allow the server time to bind and start its accept loop.
+        std::thread::sleep(Duration::from_millis(300));
+
+        // A successful TCP connect proves the server is listening.
+        std::net::TcpStream::connect(format!("127.0.0.1:{port}"))
+            .expect("HTTP/2+TLS server should accept TCP connections");
+
+        // Signal a graceful shutdown.
+        cancel_tx.send(()).expect("cancel signal must be sent");
+
+        let result = server_thread
+            .join()
+            .expect("server thread should not panic");
+        assert!(
+            result.is_ok(),
+            "HTTP/2+TLS server should shut down cleanly, got: {:?}",
+            result
+        );
+    }
+}

--- a/tests/tls.rs
+++ b/tests/tls.rs
@@ -3,18 +3,6 @@
 #![deny(rust_2018_idioms)]
 #![deny(dead_code)]
 
-/// Grab a free local port by briefly binding to 0 and reading back the
-/// OS-assigned port. The listener is immediately dropped so the port is
-/// available when the server binds to it.
-#[cfg(feature = "tls")]
-fn free_port() -> u16 {
-    std::net::TcpListener::bind("127.0.0.1:0")
-        .expect("failed to find a free port")
-        .local_addr()
-        .unwrap()
-        .port()
-}
-
 // Settings validation tests
 
 #[cfg(test)]
@@ -164,86 +152,388 @@ mod settings_tests {
     }
 }
 
-// Live server tests
+// ---------------------------------------------------------------------------
+// Live server integration tests
+// ---------------------------------------------------------------------------
+//
+// Each test spawns a real SWS server in a dedicated thread (with its own tokio
+// runtime) and connects to it using a TLS client. To avoid flakiness:
+//
+// 1. Ports are allocated by the OS via binding to port 0.
+// 2. Readiness is determined by polling TCP connect (not sleeping).
+// 3. Every async operation is wrapped in `tokio::time::timeout`.
+// 4. The server is shut down via a watch channel, and `server.join()` is
+//    performed in a blocking spawn to avoid starving the test runtime.
 
-/// Live-server tests that spin up a real TLS listener, assert that TCP
-/// connections are accepted and then shut the server down via a cancel channel.
 #[cfg(feature = "tls")]
-#[cfg(test)]
-mod live_server_tests {
-    use super::free_port;
-    use static_web_server::{Server, Settings};
-    use std::time::Duration;
+mod test_helpers {
+    use rustls_pki_types::{CertificateDer, ServerName, UnixTime};
+    use std::sync::Arc;
+    use tokio_rustls::rustls::{
+        ClientConfig, DigitallySignedStruct, Error as TlsError, SignatureScheme,
+        client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier},
+    };
 
-    const CERT: &str = "tests/tls/local.dev_cert.pkcs8.pem";
-    const KEY: &str = "tests/tls/local.dev_key.pkcs8.pem";
+    /// Maximum time any single test operation is allowed to take.
+    pub const TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 
-    /// Start an HTTP/1+TLS server on a free port, verify that a raw TCP
-    /// connection is accepted (proving the listener is up), then cancel the
-    /// server and confirm it exits cleanly.
-    #[test]
-    fn http1_tls_server_starts_and_accepts_connections() {
-        let port = free_port();
+    /// Grab a free local port.
+    pub fn free_port() -> u16 {
+        std::net::TcpListener::bind("127.0.0.1:0")
+            .expect("bind to port 0")
+            .local_addr()
+            .unwrap()
+            .port()
+    }
+
+    /// Wait until the server is accepting TCP connections on `port`.
+    pub async fn wait_for_server(port: u16) {
+        for _ in 0..50 {
+            if tokio::net::TcpStream::connect(("127.0.0.1", port))
+                .await
+                .is_ok()
+            {
+                return;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+        panic!("server did not become ready on port {port} within 2.5s");
+    }
+
+    /// Build a rustls `ClientConfig` that skips certificate verification (safe
+    /// for tests where we control both ends) and advertises the given ALPN.
+    pub fn tls_client_config(alpn: &[&str]) -> Arc<ClientConfig> {
+        #[derive(Debug)]
+        struct NoVerify;
+
+        impl ServerCertVerifier for NoVerify {
+            fn verify_server_cert(
+                &self,
+                _end_entity: &CertificateDer<'_>,
+                _intermediates: &[CertificateDer<'_>],
+                _server_name: &ServerName<'_>,
+                _ocsp_response: &[u8],
+                _now: UnixTime,
+            ) -> Result<ServerCertVerified, TlsError> {
+                Ok(ServerCertVerified::assertion())
+            }
+
+            fn verify_tls12_signature(
+                &self,
+                _message: &[u8],
+                _cert: &CertificateDer<'_>,
+                _dss: &DigitallySignedStruct,
+            ) -> Result<HandshakeSignatureValid, TlsError> {
+                Ok(HandshakeSignatureValid::assertion())
+            }
+
+            fn verify_tls13_signature(
+                &self,
+                _message: &[u8],
+                _cert: &CertificateDer<'_>,
+                _dss: &DigitallySignedStruct,
+            ) -> Result<HandshakeSignatureValid, TlsError> {
+                Ok(HandshakeSignatureValid::assertion())
+            }
+
+            fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+                vec![
+                    SignatureScheme::RSA_PKCS1_SHA256,
+                    SignatureScheme::RSA_PKCS1_SHA384,
+                    SignatureScheme::RSA_PKCS1_SHA512,
+                    SignatureScheme::ECDSA_NISTP256_SHA256,
+                    SignatureScheme::ECDSA_NISTP384_SHA384,
+                    SignatureScheme::ECDSA_NISTP521_SHA512,
+                    SignatureScheme::RSA_PSS_SHA256,
+                    SignatureScheme::RSA_PSS_SHA384,
+                    SignatureScheme::RSA_PSS_SHA512,
+                    SignatureScheme::ED25519,
+                ]
+            }
+        }
+
+        let mut cfg = ClientConfig::builder()
+            .dangerous()
+            .with_custom_certificate_verifier(Arc::new(NoVerify))
+            .with_no_client_auth();
+        cfg.alpn_protocols = alpn.iter().map(|p| p.as_bytes().to_vec()).collect();
+        Arc::new(cfg)
+    }
+
+    /// Spawn a TLS-enabled SWS server in a background thread.
+    pub fn spawn_server(
+        port: u16,
+        extra_args: &[&str],
+    ) -> (
+        tokio::sync::watch::Sender<()>,
+        std::thread::JoinHandle<static_web_server::Result>,
+    ) {
+        const CERT: &str = "tests/tls/local.dev_cert.pkcs8.pem";
+        const KEY: &str = "tests/tls/local.dev_key.pkcs8.pem";
 
         let (cancel_tx, cancel_rx) = tokio::sync::watch::channel(());
-
         let port_str = port.to_string();
-        let server_thread = std::thread::spawn(move || {
-            let settings = Settings::get_unparsed(
-                false,
-                &[
-                    "static-web-server",
-                    "--root",
-                    "tests/fixtures/public",
-                    "--host",
-                    "127.0.0.1",
-                    "--port",
-                    &port_str,
-                    "--tls",
-                    "--tls-cert",
-                    CERT,
-                    "--tls-key",
-                    KEY,
-                ],
-            )
-            .expect("settings must parse");
 
-            Server::new(settings)
-                .expect("server must build")
+        let mut args: Vec<String> = [
+            "static-web-server",
+            "--root",
+            "tests/fixtures/public",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            &port_str,
+            "--tls",
+            "--tls-cert",
+            CERT,
+            "--tls-key",
+            KEY,
+        ]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+
+        for a in extra_args {
+            args.push(a.to_string());
+        }
+
+        let handle = std::thread::spawn(move || {
+            let refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+            let settings =
+                static_web_server::Settings::get_unparsed(false, &refs).expect("settings parse");
+            static_web_server::Server::new(settings)
+                .expect("server build")
                 .run_server_on_rt(Some(cancel_rx), || {}, false)
         });
 
-        // Allow the server time to bind and start its accept loop.
-        std::thread::sleep(Duration::from_millis(300));
-
-        // A successful TCP connect proves the server is listening.
-        std::net::TcpStream::connect(format!("127.0.0.1:{port}"))
-            .expect("TLS server should accept TCP connections");
-
-        // Signal a graceful shutdown.
-        cancel_tx.send(()).expect("cancel signal must be sent");
-
-        let result = server_thread
-            .join()
-            .expect("server thread should not panic");
-        assert!(
-            result.is_ok(),
-            "server should shut down cleanly, got: {:?}",
-            result
-        );
+        (cancel_tx, handle)
     }
 
-    /// Starting a TLS server with a cert/key pair of a different algorithm
-    /// (e.g. RSA cert with EC key) must fail before accepting any connections.
-    #[test]
-    fn http1_tls_server_mismatched_cert_key_fails_to_start() {
+    /// Spawn a plain HTTP/1 (no TLS) server.
+    pub fn spawn_plain_server(
+        port: u16,
+        extra_args: &[&str],
+    ) -> (
+        tokio::sync::watch::Sender<()>,
+        std::thread::JoinHandle<static_web_server::Result>,
+    ) {
+        let (cancel_tx, cancel_rx) = tokio::sync::watch::channel(());
+        let port_str = port.to_string();
+
+        let mut args: Vec<String> = [
+            "static-web-server",
+            "--root",
+            "tests/fixtures/public",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            &port_str,
+        ]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+
+        for a in extra_args {
+            args.push(a.to_string());
+        }
+
+        let handle = std::thread::spawn(move || {
+            let refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+            let settings =
+                static_web_server::Settings::get_unparsed(false, &refs).expect("settings parse");
+            static_web_server::Server::new(settings)
+                .expect("server build")
+                .run_server_on_rt(Some(cancel_rx), || {}, false)
+        });
+
+        (cancel_tx, handle)
+    }
+
+    /// Send cancel and join the server thread with a timeout.
+    pub async fn shutdown_server(
+        cancel_tx: tokio::sync::watch::Sender<()>,
+        handle: std::thread::JoinHandle<static_web_server::Result>,
+    ) {
+        let _ = cancel_tx.send(());
+        // Join in a blocking task to avoid starving the async runtime.
+        let join_result = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            tokio::task::spawn_blocking(move || handle.join().expect("server thread panicked")),
+        )
+        .await;
+
+        match join_result {
+            Ok(Ok(server_result)) => {
+                server_result.ok();
+            }
+            Ok(Err(e)) => panic!("spawn_blocking panicked: {e:?}"),
+            Err(_) => {
+                // Server didn't shut down within 5s — not ideal but don't block the test.
+                eprintln!("warning: server did not shut down within 5s after cancel");
+            }
+        }
+    }
+}
+
+#[cfg(feature = "tls")]
+#[cfg(test)]
+mod live_http1_plain_tests {
+    use http::StatusCode;
+    use http_body_util::Empty;
+    use hyper::Request;
+    use hyper_util::rt::TokioIo;
+
+    use super::test_helpers::*;
+
+    async fn http_get(port: u16, path: &str) -> StatusCode {
+        let stream = tokio::net::TcpStream::connect(("127.0.0.1", port))
+            .await
+            .expect("TCP connect");
+
+        let (mut sender, conn) = hyper::client::conn::http1::handshake(TokioIo::new(stream))
+            .await
+            .expect("HTTP/1 handshake");
+        tokio::spawn(conn);
+
+        let req = Request::builder()
+            .uri(path)
+            .header("host", format!("localhost:{port}"))
+            .body(Empty::<bytes::Bytes>::new())
+            .unwrap();
+
+        sender
+            .send_request(req)
+            .await
+            .expect("send request")
+            .status()
+    }
+
+    #[tokio::test]
+    async fn http1_plain_serves_files() {
         let port = free_port();
+        let (cancel_tx, handle) = spawn_plain_server(port, &[]);
+        wait_for_server(port).await;
 
+        let status = tokio::time::timeout(TIMEOUT, http_get(port, "/index.htm"))
+            .await
+            .expect("request timed out");
+        assert_eq!(status, StatusCode::OK);
+
+        shutdown_server(cancel_tx, handle).await;
+    }
+
+    #[tokio::test]
+    async fn http1_plain_returns_404() {
+        let port = free_port();
+        let (cancel_tx, handle) = spawn_plain_server(port, &[]);
+        wait_for_server(port).await;
+
+        let status = tokio::time::timeout(TIMEOUT, http_get(port, "/no-such-file.html"))
+            .await
+            .expect("request timed out");
+        assert_eq!(status, StatusCode::NOT_FOUND);
+
+        shutdown_server(cancel_tx, handle).await;
+    }
+}
+
+#[cfg(feature = "tls")]
+#[cfg(test)]
+mod live_http1_tls_tests {
+    use http::StatusCode;
+    use http_body_util::Empty;
+    use hyper::Request;
+    use hyper_util::rt::TokioIo;
+    use rustls_pki_types::ServerName;
+    use tokio_rustls::TlsConnector;
+
+    use super::test_helpers::*;
+
+    async fn https_get_http1(port: u16, path: &str) -> StatusCode {
+        let cfg = tls_client_config(&["http/1.1"]);
+        let connector = TlsConnector::from(cfg);
+        let stream = tokio::net::TcpStream::connect(("127.0.0.1", port))
+            .await
+            .expect("TCP connect");
+        let domain = ServerName::try_from("localhost").unwrap().to_owned();
+        let tls_stream = connector
+            .connect(domain, stream)
+            .await
+            .expect("TLS handshake");
+
+        let (mut sender, conn) = hyper::client::conn::http1::handshake(TokioIo::new(tls_stream))
+            .await
+            .expect("HTTP/1 handshake");
+        tokio::spawn(conn);
+
+        let req = Request::builder()
+            .uri(path)
+            .header("host", format!("localhost:{port}"))
+            .body(Empty::<bytes::Bytes>::new())
+            .unwrap();
+
+        sender
+            .send_request(req)
+            .await
+            .expect("send request")
+            .status()
+    }
+
+    #[tokio::test]
+    async fn serves_files() {
+        let port = free_port();
+        let (cancel_tx, handle) = spawn_server(port, &[]);
+        wait_for_server(port).await;
+
+        let status = tokio::time::timeout(TIMEOUT, https_get_http1(port, "/index.htm"))
+            .await
+            .expect("request timed out");
+        assert_eq!(status, StatusCode::OK);
+
+        shutdown_server(cancel_tx, handle).await;
+    }
+
+    #[tokio::test]
+    async fn returns_404_for_missing_file() {
+        let port = free_port();
+        let (cancel_tx, handle) = spawn_server(port, &[]);
+        wait_for_server(port).await;
+
+        let status = tokio::time::timeout(TIMEOUT, https_get_http1(port, "/no-such-file.html"))
+            .await
+            .expect("request timed out");
+        assert_eq!(status, StatusCode::NOT_FOUND);
+
+        shutdown_server(cancel_tx, handle).await;
+    }
+
+    #[tokio::test]
+    async fn tls_handshake_completes() {
+        let port = free_port();
+        let (cancel_tx, handle) = spawn_server(port, &[]);
+        wait_for_server(port).await;
+
+        let cfg = tls_client_config(&["http/1.1"]);
+        let connector = TlsConnector::from(cfg);
+        let stream = tokio::net::TcpStream::connect(("127.0.0.1", port))
+            .await
+            .expect("TCP connect");
+        let domain = ServerName::try_from("localhost").unwrap().to_owned();
+        let result = tokio::time::timeout(TIMEOUT, connector.connect(domain, stream)).await;
+        assert!(
+            result.is_ok() && result.unwrap().is_ok(),
+            "TLS handshake should complete"
+        );
+
+        shutdown_server(cancel_tx, handle).await;
+    }
+
+    #[test]
+    fn mismatched_cert_key_fails_to_start() {
+        let port = free_port();
         let (_, cancel_rx) = tokio::sync::watch::channel(());
-
         let port_str = port.to_string();
         let result = std::thread::spawn(move || {
-            let settings = Settings::get_unparsed(
+            let settings = static_web_server::Settings::get_unparsed(
                 false,
                 &[
                     "static-web-server",
@@ -261,8 +551,7 @@ mod live_server_tests {
                 ],
             )
             .expect("settings must parse");
-
-            Server::new(settings)
+            static_web_server::Server::new(settings)
                 .expect("server must build")
                 .run_server_on_rt(Some(cancel_rx), || {}, false)
         })
@@ -276,70 +565,94 @@ mod live_server_tests {
     }
 }
 
-/// Live HTTP/2+TLS server tests.
 #[cfg(all(feature = "tls", feature = "http2"))]
 #[cfg(test)]
-mod live_http2_server_tests {
-    use super::free_port;
-    use static_web_server::{Server, Settings};
-    use std::time::Duration;
+mod live_http2_tls_tests {
+    use http::StatusCode;
+    use http_body_util::Empty;
+    use hyper::Request;
+    use hyper_util::rt::{TokioExecutor, TokioIo};
+    use rustls_pki_types::ServerName;
+    use tokio_rustls::TlsConnector;
 
-    const CERT: &str = "tests/tls/local.dev_cert.pkcs8.pem";
-    const KEY: &str = "tests/tls/local.dev_key.pkcs8.pem";
+    use super::test_helpers::*;
 
-    /// Start an HTTP/2+TLS server on a free port, verify that a raw TCP
-    /// connection is accepted (proving the listener is up), then cancel the
-    /// server and confirm it exits cleanly.
-    #[test]
-    fn http2_tls_server_starts_and_accepts_connections() {
+    async fn https_get_http2(port: u16, path: &str) -> StatusCode {
+        let cfg = tls_client_config(&["h2"]);
+        let connector = TlsConnector::from(cfg);
+        let stream = tokio::net::TcpStream::connect(("127.0.0.1", port))
+            .await
+            .expect("TCP connect");
+        let domain = ServerName::try_from("localhost").unwrap().to_owned();
+        let tls_stream = connector
+            .connect(domain, stream)
+            .await
+            .expect("TLS handshake");
+
+        let (mut sender, conn) =
+            hyper::client::conn::http2::handshake(TokioExecutor::new(), TokioIo::new(tls_stream))
+                .await
+                .expect("HTTP/2 handshake");
+        tokio::spawn(conn);
+
+        let req = Request::builder()
+            .uri(format!("https://localhost:{port}{path}"))
+            .body(Empty::<bytes::Bytes>::new())
+            .unwrap();
+
+        sender
+            .send_request(req)
+            .await
+            .expect("send request")
+            .status()
+    }
+
+    #[tokio::test]
+    async fn serves_files() {
         let port = free_port();
+        let (cancel_tx, handle) = spawn_server(port, &["--http2"]);
+        wait_for_server(port).await;
 
-        let (cancel_tx, cancel_rx) = tokio::sync::watch::channel(());
+        let status = tokio::time::timeout(TIMEOUT, https_get_http2(port, "/index.htm"))
+            .await
+            .expect("request timed out");
+        assert_eq!(status, StatusCode::OK);
 
-        let port_str = port.to_string();
-        let server_thread = std::thread::spawn(move || {
-            let settings = Settings::get_unparsed(
-                false,
-                &[
-                    "static-web-server",
-                    "--root",
-                    "tests/fixtures/public",
-                    "--host",
-                    "127.0.0.1",
-                    "--port",
-                    &port_str,
-                    "--tls",
-                    "--tls-cert",
-                    CERT,
-                    "--tls-key",
-                    KEY,
-                    "--http2",
-                ],
-            )
-            .expect("settings must parse");
+        shutdown_server(cancel_tx, handle).await;
+    }
 
-            Server::new(settings)
-                .expect("server must build")
-                .run_server_on_rt(Some(cancel_rx), || {}, false)
-        });
+    #[tokio::test]
+    async fn returns_404_for_missing_file() {
+        let port = free_port();
+        let (cancel_tx, handle) = spawn_server(port, &["--http2"]);
+        wait_for_server(port).await;
 
-        // Allow the server time to bind and start its accept loop.
-        std::thread::sleep(Duration::from_millis(300));
+        let status = tokio::time::timeout(TIMEOUT, https_get_http2(port, "/no-such-file.html"))
+            .await
+            .expect("request timed out");
+        assert_eq!(status, StatusCode::NOT_FOUND);
 
-        // A successful TCP connect proves the server is listening.
-        std::net::TcpStream::connect(format!("127.0.0.1:{port}"))
-            .expect("HTTP/2+TLS server should accept TCP connections");
+        shutdown_server(cancel_tx, handle).await;
+    }
 
-        // Signal a graceful shutdown.
-        cancel_tx.send(()).expect("cancel signal must be sent");
+    #[tokio::test]
+    async fn tls_handshake_with_h2_alpn() {
+        let port = free_port();
+        let (cancel_tx, handle) = spawn_server(port, &["--http2"]);
+        wait_for_server(port).await;
 
-        let result = server_thread
-            .join()
-            .expect("server thread should not panic");
+        let cfg = tls_client_config(&["h2"]);
+        let connector = TlsConnector::from(cfg);
+        let stream = tokio::net::TcpStream::connect(("127.0.0.1", port))
+            .await
+            .expect("TCP connect");
+        let domain = ServerName::try_from("localhost").unwrap().to_owned();
+        let result = tokio::time::timeout(TIMEOUT, connector.connect(domain, stream)).await;
         assert!(
-            result.is_ok(),
-            "HTTP/2+TLS server should shut down cleanly, got: {:?}",
-            result
+            result.is_ok() && result.unwrap().is_ok(),
+            "TLS handshake with h2 ALPN should succeed"
         );
+
+        shutdown_server(cancel_tx, handle).await;
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Read the docs/PULL_REQUESTS.md -->

## Description
<!--- Describe your changes but try to be as concise as possible -->

This PR splits out the TLS feature from the HTTP/2 one by removing `--http2`, `--http2-tls-cert`, `--http2-tls-cert` and introducing the following options instead:

- `--tls` to enable the TLS feature.
- `--tls-cert` to provide TLS certificate.
- `--tls-key` to provide the TLS private key.
- `--http2` to enable the HTTP/2 feature.

With that, SWS now supports the following server modes:

- HTTP/1
- HTTP/1 + TLS
- HTTP/2 + TLS (it requires the new `--http2` option)

Example:

```sh
static-web-server \
    --host 127.0.0.1 \
    --port 8787 \
    --root ./my-public-dir \
    --tls \
    --tls-cert ./my-tls.cert \
    --tls-key ./my-tls.key
    # add the --http2 option for HTTP/2 + TLS (optional)
    --http2
```

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- See how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
