### PR TITLE
Optional default charset for text/* file responses (#655)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ This new `v2.42.0` brings bug fixes, new features and improvements. Fix a memory
 
 **Docs**
 
-- [0a8c8ca][0a8c8ca] Metrics feature documenation page. PR [#633][633] by [@chrissnell][chrissnell] See [docs](https://static-web-server.net/features/metrics)
+- [0a8c8ca][0a8c8ca] Metrics feature documentation page. PR [#633][633] by [@chrissnell][chrissnell] See [docs](https://static-web-server.net/features/metrics)
 - [b6856ea][b6856ea] Local-time support for logs. PR [#638][638] by [@joseluisq][joseluisq]
 
 [0a8c8ca]: https://github.com/static-web-server/static-web-server/commit/0a8c8ca

--- a/docs/content/configuration/command-line-arguments.md
+++ b/docs/content/configuration/command-line-arguments.md
@@ -104,6 +104,8 @@ Options:
           Add a /health endpoint that doesn't generate any log entry and returns a 200 status code. This is especially useful with Kubernetes liveness and readiness probes [env: SERVER_HEALTH=] [default: false] [possible values: true, false]
       --accept-markdown [<ACCEPT_MARKDOWN>]
           Enable markdown content negotiation. When a client sends Accept: text/markdown header, the server will serve markdown files (.md or .html.md) if available [env: SERVER_ACCEPT_MARKDOWN=] [default: false] [possible values: true, false]
+      --text-charset <TEXT_CHARSET>
+          Declare a default `charset` parameter on `text/*` responses that don't already have one. Set to empty to disable [env: SERVER_TEXT_CHARSET=] [default: utf-8]
       --maintenance-mode [<MAINTENANCE_MODE>]
           Enable the server's maintenance mode functionality [env: SERVER_MAINTENANCE_MODE=] [default: false] [possible values: true, false]
       --maintenance-mode-status <MAINTENANCE_MODE_STATUS>

--- a/docs/content/configuration/config-file.md
+++ b/docs/content/configuration/config-file.md
@@ -97,6 +97,9 @@ health = false
 #### Markdown content negotiation
 accept-markdown = false
 
+#### Default charset for text/* responses (empty to disable)
+text-charset = "utf-8"
+
 #### List of index files
 # index-files = "index.html, index.htm"
 #### Maintenance Mode

--- a/docs/content/configuration/environment-variables.md
+++ b/docs/content/configuration/environment-variables.md
@@ -177,6 +177,10 @@ Activate the health endpoint.
 
 Enable markdown content negotiation. When a client sends `Accept: text/markdown` header, the server will serve markdown files (`.md` or `.html.md`) if available. See [Markdown Content Negotiation](../features/markdown-content-negotiation.md) for details. Default `false`.
 
+### SERVER_TEXT_CHARSET
+
+Declare a default `charset` parameter on `text/*` responses that don't already carry one. See [Default Charset for Text Responses](../features/text-charset.md) for details. Default `utf-8`; set to an empty value to disable.
+
 ### SERVER_INDEX_FILES
 
 List of files that will be used as an index for requests ending with the slash character (‘/’). Files are checked in the specified order. Default `index.html`.

--- a/docs/content/features/text-charset.md
+++ b/docs/content/features/text-charset.md
@@ -1,0 +1,50 @@
+# Default Charset for Text Responses
+
+**`SWS`** can declare a default `charset` parameter on every `text/*` response that doesn't already carry one, mirroring Apache's `AddDefaultCharset` and nginx's `charset` directives.
+
+Without this option, files like `robots.txt`, `llms.txt`, plain READMEs or any other `text/*` resource are served without a charset parameter, and browsers fall back to a locale-specific guess (typically Windows-1252) that mojibake-corrupts any non-ASCII byte.
+
+The option is enabled by default with `utf-8` and can be controlled by the string `--text-charset` option or the equivalent [SERVER_TEXT_CHARSET](./../configuration/environment-variables.md#server_text_charset) env. Pass an empty value to disable it.
+
+## Behaviour
+
+- Applies to every response whose `Content-Type` starts with `text/`.
+- Skipped when the response already carries a `charset` parameter (e.g. markdown content negotiation, error pages).
+- Non-text responses (`application/json`, `application/javascript`, images, archives) are never touched.
+- Custom headers configured under `[[advanced.headers]]` still win over this option, because they are applied after.
+
+## Usage examples
+
+Default (no flag needed, already on):
+
+```sh
+static-web-server --root ./public
+# robots.txt is served as: Content-Type: text/plain; charset=utf-8
+```
+
+Set a different charset:
+
+```sh
+static-web-server --root ./public --text-charset iso-8859-1
+```
+
+Disable the feature entirely:
+
+```sh
+static-web-server --root ./public --text-charset ""
+```
+
+Equivalent configuration file:
+
+```toml
+[general]
+root = "./public"
+text-charset = "utf-8"
+```
+
+Equivalent environment variable:
+
+```sh
+export SERVER_TEXT_CHARSET=utf-8
+static-web-server --root ./public
+```

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -169,6 +169,7 @@ nav:
     - 'WebAssembly': 'features/webassembly.md'
     - 'Man Pages and Shell Completions': 'features/man-pages-completions.md'
     - 'Markdown Content Negotiation': 'features/markdown-content-negotiation.md'
+    - 'Default Charset for Text Responses': 'features/text-charset.md'
   - 'Platforms & Architectures': 'platforms-architectures.md'
   - 'Migrating from v1 to v2': 'migration.md'
   - 'Changelog v2 (stable)': 'https://github.com/static-web-server/static-web-server/blob/master/CHANGELOG.md'

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -43,7 +43,7 @@ use crate::{
     log_addr, maintenance_mode, redirects, rewrites, security_headers,
     settings::Advanced,
     static_files::{self, HandleOpts},
-    virtual_hosts,
+    text_charset, virtual_hosts,
 };
 
 #[cfg(feature = "directory-listing")]
@@ -125,6 +125,9 @@ pub struct RequestHandlerOpts {
     pub disable_symlinks: bool,
     /// Accept markdown content negotiation feature.
     pub accept_markdown: bool,
+    /// Default `charset` parameter applied to `text/*` responses without one.
+    /// Empty disables the feature.
+    pub text_charset: String,
     /// Health endpoint feature.
     pub health: bool,
     /// Metrics endpoint feature.
@@ -183,6 +186,7 @@ impl Default for RequestHandlerOpts {
             ignore_hidden_files: false,
             disable_symlinks: false,
             accept_markdown: false,
+            text_charset: String::from("utf-8"),
             health: false,
             #[cfg(feature = "metrics")]
             metrics_enabled: false,
@@ -353,6 +357,9 @@ impl RequestHandler {
 
                 // Set Content-Type for markdown files
                 let resp = crate::markdown::post_process(uri_path_md.is_some(), &self.opts, resp)?;
+
+                // Declare a default charset for `text/*` responses
+                let resp = text_charset::post_process(&self.opts, resp)?;
 
                 // Add a `Vary` header if static compression is used
                 let resp = compression_static::post_process(&self.opts, req, resp)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,6 +173,7 @@ pub mod settings;
 #[cfg_attr(docsrs, doc(cfg(any(unix, windows))))]
 pub mod signals;
 pub mod static_files;
+pub(crate) mod text_charset;
 #[cfg(feature = "http2")]
 #[cfg_attr(docsrs, doc(cfg(feature = "http2")))]
 pub mod tls;

--- a/src/server.rs
+++ b/src/server.rs
@@ -267,6 +267,13 @@ impl Server {
         let disable_symlinks = general.disable_symlinks;
         tracing::info!("disable symlinks: enabled={}", disable_symlinks);
 
+        // Default charset for text/* responses
+        if general.text_charset.is_empty() {
+            tracing::info!("text charset: disabled");
+        } else {
+            tracing::info!("text charset: {}", general.text_charset);
+        }
+
         // Grace period option
         let grace_period = general.grace_period;
         tracing::info!("grace period before graceful shutdown: {}s", grace_period);
@@ -295,6 +302,7 @@ impl Server {
             ignore_hidden_files,
             disable_symlinks,
             accept_markdown: general.accept_markdown,
+            text_charset: general.text_charset,
             index_files,
             advanced_opts,
             ..Default::default()

--- a/src/settings/cli.rs
+++ b/src/settings/cli.rs
@@ -512,6 +512,10 @@ pub struct General {
     /// Enable markdown content negotiation. When a client sends Accept: text/markdown, serve .md or .html.md files if available.
     pub accept_markdown: bool,
 
+    #[arg(long, default_value = "utf-8", env = "SERVER_TEXT_CHARSET")]
+    /// Declare a default `charset` parameter on `text/*` responses that don't already have one. Set to empty to disable.
+    pub text_charset: String,
+
     #[arg(
         long,
         default_value = "false",

--- a/src/settings/file.rs
+++ b/src/settings/file.rs
@@ -374,6 +374,9 @@ pub struct General {
     /// Accept markdown content negotiation feature.
     pub accept_markdown: Option<bool>,
 
+    /// Default `charset` parameter for `text/*` responses (empty disables).
+    pub text_charset: Option<String>,
+
     #[cfg(feature = "metrics")]
     /// Metrics endpoint feature.
     pub metrics: Option<bool>,

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -13,7 +13,7 @@ use hyper::StatusCode;
 use regex_lite::Regex;
 use std::path::{Path, PathBuf};
 
-use crate::{Context, Result, helpers, logger};
+use crate::{Context, Result, helpers, logger, text_charset};
 
 pub mod cli;
 #[doc(hidden)]
@@ -201,6 +201,7 @@ impl Settings {
         let mut ignore_hidden_files = opts.ignore_hidden_files;
         let mut disable_symlinks = opts.disable_symlinks;
         let mut accept_markdown = opts.accept_markdown;
+        let mut text_charset = opts.text_charset;
         let mut index_files = opts.index_files;
         let mut health = opts.health;
 
@@ -395,6 +396,9 @@ impl Settings {
                 }
                 if let Some(v) = general.accept_markdown {
                     accept_markdown = v
+                }
+                if let Some(v) = general.text_charset {
+                    text_charset = v
                 }
                 #[cfg(feature = "metrics")]
                 if let Some(v) = general.metrics {
@@ -608,6 +612,10 @@ impl Settings {
             logger::init(log_level.as_str(), log_with_ansi)?;
         }
 
+        if !text_charset.is_empty() && !text_charset::is_valid_charset(&text_charset) {
+            bail!("invalid text-charset value: {text_charset:?}");
+        }
+
         Ok(Settings {
             general: General {
                 version,
@@ -679,6 +687,7 @@ impl Settings {
                 ignore_hidden_files,
                 disable_symlinks,
                 accept_markdown,
+                text_charset,
                 index_files,
                 health,
                 #[cfg(feature = "metrics")]

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -109,6 +109,7 @@ pub mod fixtures {
             ignore_hidden_files: general.ignore_hidden_files,
             disable_symlinks: general.disable_symlinks,
             accept_markdown: general.accept_markdown,
+            text_charset: general.text_charset,
             index_files: general
                 .index_files
                 .split(',')

--- a/src/text_charset.rs
+++ b/src/text_charset.rs
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// This file is part of Static Web Server.
+// See https://static-web-server.net/ for more information
+// Copyright (C) 2019-present Jose Quintana <joseluisq.net>
+
+//! Declares a default `charset` parameter on `text/*` responses that don't
+//! already have one. Similar in spirit to Apache's `AddDefaultCharset` and
+//! nginx's `charset` directives, applied here to every `text/*` subtype.
+
+use hyper::{
+    Body, Response,
+    header::{CONTENT_TYPE, HeaderValue},
+};
+
+use crate::{Error, handler::RequestHandlerOpts};
+
+/// Validates a charset value against the RFC 7230 `token` grammar.
+pub(crate) fn is_valid_charset(value: &str) -> bool {
+    !value.is_empty()
+        && value.bytes().all(|b| {
+            b.is_ascii_alphanumeric()
+                || matches!(
+                    b,
+                    b'!' | b'#'
+                        | b'$'
+                        | b'%'
+                        | b'&'
+                        | b'\''
+                        | b'*'
+                        | b'+'
+                        | b'-'
+                        | b'.'
+                        | b'^'
+                        | b'_'
+                        | b'`'
+                        | b'|'
+                        | b'~'
+                )
+        })
+}
+
+/// Adds `; charset=<value>` to the `Content-Type` header when the response
+/// type is `text/*` and no `charset` parameter is already present. A no-op
+/// when the option is disabled (empty value).
+pub(crate) fn post_process(
+    opts: &RequestHandlerOpts,
+    mut resp: Response<Body>,
+) -> Result<Response<Body>, Error> {
+    if opts.text_charset.is_empty() {
+        return Ok(resp);
+    }
+
+    let ct = match resp
+        .headers()
+        .get(CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+    {
+        Some(v) if is_text(v) && !has_charset_param(v) => v,
+        _ => return Ok(resp),
+    };
+
+    if let Ok(value) = HeaderValue::from_str(&format!("{ct}; charset={}", opts.text_charset)) {
+        resp.headers_mut().insert(CONTENT_TYPE, value);
+    }
+    Ok(resp)
+}
+
+fn is_text(content_type: &str) -> bool {
+    content_type
+        .get(..5)
+        .is_some_and(|p| p.eq_ignore_ascii_case("text/"))
+}
+
+fn has_charset_param(content_type: &str) -> bool {
+    content_type.split(';').skip(1).any(|param| {
+        param
+            .trim_start()
+            .get(..8)
+            .is_some_and(|p| p.eq_ignore_ascii_case("charset="))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hyper::Body;
+
+    fn opts(charset: &str) -> RequestHandlerOpts {
+        RequestHandlerOpts {
+            text_charset: charset.to_owned(),
+            ..Default::default()
+        }
+    }
+
+    fn resp_with(ct: &str) -> Response<Body> {
+        let mut resp = Response::new(Body::empty());
+        resp.headers_mut()
+            .insert(CONTENT_TYPE, HeaderValue::from_str(ct).unwrap());
+        resp
+    }
+
+    fn ct(resp: &Response<Body>) -> &str {
+        resp.headers().get(CONTENT_TYPE).unwrap().to_str().unwrap()
+    }
+
+    #[test]
+    fn annotates_bare_text_type() {
+        let r = post_process(&opts("utf-8"), resp_with("text/plain")).unwrap();
+        assert_eq!(ct(&r), "text/plain; charset=utf-8");
+    }
+
+    #[test]
+    fn annotates_text_markdown() {
+        let r = post_process(&opts("utf-8"), resp_with("text/markdown")).unwrap();
+        assert_eq!(ct(&r), "text/markdown; charset=utf-8");
+    }
+
+    #[test]
+    fn preserves_existing_charset() {
+        let r = post_process(&opts("utf-8"), resp_with("text/html; charset=iso-8859-1")).unwrap();
+        assert_eq!(ct(&r), "text/html; charset=iso-8859-1");
+    }
+
+    #[test]
+    fn preserves_charset_with_unusual_casing_and_spacing() {
+        let r = post_process(&opts("utf-8"), resp_with("text/html;CHARSET=utf-8")).unwrap();
+        assert_eq!(ct(&r), "text/html;CHARSET=utf-8");
+    }
+
+    #[test]
+    fn preserves_charset_when_not_first_param() {
+        let r = post_process(
+            &opts("utf-8"),
+            resp_with("text/plain; foo=bar; charset=latin1"),
+        )
+        .unwrap();
+        assert_eq!(ct(&r), "text/plain; foo=bar; charset=latin1");
+    }
+
+    #[test]
+    fn ignores_non_text_type() {
+        let r = post_process(&opts("utf-8"), resp_with("application/json")).unwrap();
+        assert_eq!(ct(&r), "application/json");
+    }
+
+    #[test]
+    fn ignores_when_disabled() {
+        let r = post_process(&opts(""), resp_with("text/plain")).unwrap();
+        assert_eq!(ct(&r), "text/plain");
+    }
+
+    #[test]
+    fn ignores_when_content_type_missing() {
+        let r = post_process(&opts("utf-8"), Response::new(Body::empty())).unwrap();
+        assert!(r.headers().get(CONTENT_TYPE).is_none());
+    }
+
+    #[test]
+    fn appends_when_unrelated_param_present() {
+        let r = post_process(&opts("utf-8"), resp_with("text/plain; boundary=x")).unwrap();
+        assert_eq!(ct(&r), "text/plain; boundary=x; charset=utf-8");
+    }
+
+    #[test]
+    fn validates_charset_tokens() {
+        assert!(is_valid_charset("utf-8"));
+        assert!(is_valid_charset("ISO-8859-1"));
+        assert!(is_valid_charset("windows-1252"));
+        assert!(!is_valid_charset(""));
+        assert!(!is_valid_charset("utf 8"));
+        assert!(!is_valid_charset("utf\"8"));
+    }
+}

--- a/tests/compression.rs
+++ b/tests/compression.rs
@@ -49,7 +49,7 @@ pub mod tests {
                 assert_eq!(res.status(), 200);
                 assert_eq!(
                     res.headers().get("content-type"),
-                    Some(&HeaderValue::from_static("text/html"))
+                    Some(&HeaderValue::from_static("text/html; charset=utf-8"))
                 );
                 assert_eq!(
                     res.headers().get("vary"),

--- a/tests/compression_static.rs
+++ b/tests/compression_static.rs
@@ -61,7 +61,7 @@ mod tests {
                 assert_eq!(headers["accept-ranges"], "bytes");
                 assert!(!headers["last-modified"].is_empty());
                 assert_eq!(
-                    &headers["content-type"], "text/html",
+                    &headers["content-type"], "text/html; charset=utf-8",
                     "content-type is not html"
                 );
                 assert_eq!(headers["vary"], "accept-encoding");
@@ -113,7 +113,7 @@ mod tests {
                 assert_eq!(headers["accept-ranges"], "bytes");
                 assert!(!headers["last-modified"].is_empty());
                 assert_eq!(
-                    &headers["content-type"], "text/html",
+                    &headers["content-type"], "text/html; charset=utf-8",
                     "content-type is not html"
                 );
                 assert_eq!(headers["vary"], "accept-encoding");
@@ -158,7 +158,7 @@ mod tests {
                 assert_eq!(headers["content-encoding"], "br");
                 assert!(!headers["last-modified"].is_empty());
                 assert_eq!(
-                    &headers["content-type"], "text/html",
+                    &headers["content-type"], "text/html; charset=utf-8",
                     "content-type is not html"
                 );
                 assert_eq!(headers["vary"], "accept-encoding");
@@ -200,7 +200,7 @@ mod tests {
                 assert_eq!(headers["content-encoding"], "br");
                 assert!(!headers["last-modified"].is_empty());
                 assert_eq!(
-                    &headers["content-type"], "text/html",
+                    &headers["content-type"], "text/html; charset=utf-8",
                     "content-type is not html"
                 );
                 assert_eq!(headers["vary"], "accept-encoding");
@@ -244,7 +244,7 @@ mod tests {
                 assert_eq!(headers["accept-ranges"], "bytes");
                 assert!(!headers["last-modified"].is_empty());
                 assert_eq!(
-                    &headers["content-type"], "text/css",
+                    &headers["content-type"], "text/css; charset=utf-8",
                     "content-type is not css"
                 );
                 assert_eq!(headers["vary"], "accept-encoding");

--- a/tests/cors.rs
+++ b/tests/cors.rs
@@ -225,7 +225,7 @@ mod tests {
                         assert_eq!(resp.status(), 200);
                         assert_eq!(
                             resp.headers().get("content-type"),
-                            Some(&HeaderValue::from_static("text/html"))
+                            Some(&HeaderValue::from_static("text/html; charset=utf-8"))
                         );
                         assert_eq!(
                             resp.headers().get("server"),

--- a/tests/fixtures/toml/text_charset_custom.toml
+++ b/tests/fixtures/toml/text_charset_custom.toml
@@ -1,0 +1,3 @@
+[general]
+root = "tests/fixtures/markdown"
+text-charset = "iso-8859-1"

--- a/tests/fixtures/toml/text_charset_default.toml
+++ b/tests/fixtures/toml/text_charset_default.toml
@@ -1,0 +1,2 @@
+[general]
+root = "tests/fixtures/markdown"

--- a/tests/fixtures/toml/text_charset_disabled.toml
+++ b/tests/fixtures/toml/text_charset_disabled.toml
@@ -1,0 +1,3 @@
+[general]
+root = "tests/fixtures/markdown"
+text-charset = ""

--- a/tests/fixtures/toml/text_charset_override.toml
+++ b/tests/fixtures/toml/text_charset_override.toml
@@ -1,0 +1,8 @@
+[general]
+root = "tests/fixtures/markdown"
+
+[advanced]
+
+[[advanced.headers]]
+source = "**/*.html"
+headers = { Content-Type = "text/html; charset=ascii" }

--- a/tests/handler.rs
+++ b/tests/handler.rs
@@ -30,7 +30,7 @@ pub mod tests {
                 assert_eq!(res.status(), 200);
                 assert_eq!(
                     res.headers().get("content-type"),
-                    Some(&HeaderValue::from_static("text/html"))
+                    Some(&HeaderValue::from_static("text/html; charset=utf-8"))
                 );
                 #[cfg(any(
                     feature = "compression",
@@ -72,7 +72,7 @@ pub mod tests {
                 assert_eq!(res.status(), 200);
                 assert_eq!(
                     res.headers().get("content-type"),
-                    Some(&HeaderValue::from_static("text/html"))
+                    Some(&HeaderValue::from_static("text/html; charset=utf-8"))
                 );
                 #[cfg(any(
                     feature = "compression",
@@ -130,7 +130,7 @@ pub mod tests {
                         assert_eq!(res.status(), 200);
                         assert_eq!(
                             res.headers().get("content-type"),
-                            Some(&HeaderValue::from_static("text/html"))
+                            Some(&HeaderValue::from_static("text/html; charset=utf-8"))
                         );
 
                         #[cfg(feature = "compression")]

--- a/tests/markdown.rs
+++ b/tests/markdown.rs
@@ -34,7 +34,7 @@ pub mod tests {
                 // Should return HTML because markdown is disabled
                 assert_eq!(
                     res.headers().get("content-type"),
-                    Some(&HeaderValue::from_static("text/html"))
+                    Some(&HeaderValue::from_static("text/html; charset=utf-8"))
                 );
 
                 let body_bytes = hyper::body::to_bytes(res.into_body()).await.unwrap();
@@ -131,7 +131,7 @@ pub mod tests {
                 assert_eq!(res.status(), 200);
                 assert_eq!(
                     res.headers().get("content-type"),
-                    Some(&HeaderValue::from_static("text/html"))
+                    Some(&HeaderValue::from_static("text/html; charset=utf-8"))
                 );
 
                 let body_bytes = hyper::body::to_bytes(res.into_body()).await.unwrap();
@@ -163,7 +163,7 @@ pub mod tests {
                 // Wildcard should NOT trigger markdown negotiation
                 assert_eq!(
                     res.headers().get("content-type"),
-                    Some(&HeaderValue::from_static("text/html"))
+                    Some(&HeaderValue::from_static("text/html; charset=utf-8"))
                 );
 
                 let body_bytes = hyper::body::to_bytes(res.into_body()).await.unwrap();
@@ -290,7 +290,7 @@ pub mod tests {
                 // Should return HTML content-type since no markdown variant exists
                 assert_eq!(
                     res.headers().get("content-type"),
-                    Some(&HeaderValue::from_static("text/html"))
+                    Some(&HeaderValue::from_static("text/html; charset=utf-8"))
                 );
 
                 let body_bytes = hyper::body::to_bytes(res.into_body()).await.unwrap();
@@ -324,7 +324,7 @@ pub mod tests {
                 // Should return HTML content-type since no markdown variant exists
                 assert_eq!(
                     res.headers().get("content-type"),
-                    Some(&HeaderValue::from_static("text/html"))
+                    Some(&HeaderValue::from_static("text/html; charset=utf-8"))
                 );
                 // Should have Content-Length header
                 assert!(res.headers().get("content-length").is_some());
@@ -352,7 +352,7 @@ pub mod tests {
                 assert_eq!(res.status(), 200);
                 assert_eq!(
                     res.headers().get("content-type"),
-                    Some(&HeaderValue::from_static("text/html"))
+                    Some(&HeaderValue::from_static("text/html; charset=utf-8"))
                 );
 
                 let body_bytes = hyper::body::to_bytes(res.into_body()).await.unwrap();
@@ -382,7 +382,7 @@ pub mod tests {
                 assert_eq!(res.status(), 200);
                 assert_eq!(
                     res.headers().get("content-type"),
-                    Some(&HeaderValue::from_static("text/html"))
+                    Some(&HeaderValue::from_static("text/html; charset=utf-8"))
                 );
                 // Should have Content-Length header
                 assert!(res.headers().get("content-length").is_some());

--- a/tests/redirects.rs
+++ b/tests/redirects.rs
@@ -25,7 +25,7 @@ pub mod tests {
         match req_handler.handle(&mut req, remote_addr).await {
             Ok(res) => {
                 assert_eq!(res.status(), 200);
-                assert_eq!(res.headers()["content-type"], "text/html");
+                assert_eq!(res.headers()["content-type"], "text/html; charset=utf-8");
             }
             Err(err) => {
                 panic!("unexpected error: {err}")

--- a/tests/rewrites.rs
+++ b/tests/rewrites.rs
@@ -26,7 +26,7 @@ pub mod tests {
         match req_handler.handle(&mut req, remote_addr).await {
             Ok(res) => {
                 assert_eq!(res.status(), 200);
-                assert_eq!(res.headers()["content-type"], "text/html");
+                assert_eq!(res.headers()["content-type"], "text/html; charset=utf-8");
             }
             Err(err) => {
                 panic!("unexpected error: {err}")
@@ -47,7 +47,7 @@ pub mod tests {
         match req_handler.handle(&mut req, remote_addr).await {
             Ok(mut res) => {
                 assert_eq!(res.status(), 200);
-                assert_eq!(res.headers()["content-type"], "text/html");
+                assert_eq!(res.headers()["content-type"], "text/html; charset=utf-8");
 
                 let body = hyper::body::to_bytes(res.body_mut())
                     .await
@@ -74,7 +74,7 @@ pub mod tests {
         match req_handler.handle(&mut req, remote_addr).await {
             Ok(mut res) => {
                 assert_eq!(res.status(), 200);
-                assert_eq!(res.headers()["content-type"], "text/html");
+                assert_eq!(res.headers()["content-type"], "text/html; charset=utf-8");
 
                 let body = hyper::body::to_bytes(res.body_mut())
                     .await
@@ -101,7 +101,7 @@ pub mod tests {
         match req_handler.handle(&mut req, remote_addr).await {
             Ok(mut res) => {
                 assert_eq!(res.status(), 200);
-                assert_eq!(res.headers()["content-type"], "text/html");
+                assert_eq!(res.headers()["content-type"], "text/html; charset=utf-8");
 
                 let body = hyper::body::to_bytes(res.body_mut())
                     .await
@@ -128,7 +128,10 @@ pub mod tests {
         match req_handler.handle(&mut req, remote_addr).await {
             Ok(mut res) => {
                 assert_eq!(res.status(), 200);
-                assert_eq!(res.headers()["content-type"], "text/javascript");
+                assert_eq!(
+                    res.headers()["content-type"],
+                    "text/javascript; charset=utf-8"
+                );
 
                 let body = hyper::body::to_bytes(res.body_mut())
                     .await

--- a/tests/text_charset.rs
+++ b/tests/text_charset.rs
@@ -1,0 +1,85 @@
+#![forbid(unsafe_code)]
+#![deny(warnings)]
+#![deny(rust_2018_idioms)]
+#![deny(dead_code)]
+
+#[cfg(test)]
+mod tests {
+    use hyper::Request;
+    use std::net::SocketAddr;
+
+    use static_web_server::Settings;
+    use static_web_server::testing::fixtures::{
+        REMOTE_ADDR, fixture_req_handler, fixture_req_handler_opts, fixture_settings,
+    };
+
+    async fn content_type(toml: &str, uri: &str) -> String {
+        let opts = fixture_settings(toml);
+        let req_handler_opts = fixture_req_handler_opts(opts.general, opts.advanced);
+        let req_handler = fixture_req_handler(req_handler_opts);
+        let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
+
+        let mut req = Request::default();
+        *req.method_mut() = hyper::Method::GET;
+        *req.uri_mut() = uri.parse().unwrap();
+
+        let res = req_handler.handle(&mut req, remote_addr).await.unwrap();
+        assert_eq!(res.status(), 200);
+        res.headers()
+            .get("content-type")
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .to_owned()
+    }
+
+    #[tokio::test]
+    async fn default_charset_is_applied() {
+        assert_eq!(
+            content_type("toml/text_charset_default.toml", "http://localhost/doc.md").await,
+            "text/markdown; charset=utf-8"
+        );
+    }
+
+    #[tokio::test]
+    async fn disabled_leaves_content_type_bare() {
+        assert_eq!(
+            content_type("toml/text_charset_disabled.toml", "http://localhost/doc.md").await,
+            "text/markdown"
+        );
+    }
+
+    #[tokio::test]
+    async fn custom_charset_is_applied() {
+        assert_eq!(
+            content_type("toml/text_charset_custom.toml", "http://localhost/doc.md").await,
+            "text/markdown; charset=iso-8859-1"
+        );
+    }
+
+    #[tokio::test]
+    async fn advanced_headers_override_wins() {
+        // [[advanced.headers]] runs after text_charset and is meant to win.
+        assert_eq!(
+            content_type(
+                "toml/text_charset_override.toml",
+                "http://localhost/article.html",
+            )
+            .await,
+            "text/html; charset=ascii"
+        );
+    }
+
+    #[test]
+    fn invalid_charset_value_is_rejected() {
+        let result = Settings::get_unparsed(
+            false,
+            &["static-web-server", "--text-charset", "utf 8 invalid"],
+        );
+        let err = result.err().expect("expected invalid charset to fail");
+        assert!(
+            err.to_string().contains("invalid text-charset"),
+            "unexpected error: {err}"
+        );
+    }
+}


### PR DESCRIPTION
## Description

This PR adds an optional `--text-charset` setting that declares a default `charset` parameter on `text/*` responses which don't already carry one. The option is enabled by default with `utf-8` and can be set to any RFC 7230 token (e.g. `iso-8859-1`) or left empty to disable the feature. It is also exposed as the `SERVER_TEXT_CHARSET` env variable and the `text-charset` key under `[general]` in the TOML configuration file.

The behaviour is conservative:

- Only `text/*` responses are touched. `application/json`, JavaScript, images and other types are never modified.
- Responses that already carry a `charset` parameter (markdown content negotiation, error pages, maintenance mode, etc.) are left untouched.
- `[[advanced.headers]]` overrides still win, since they are applied after this step.
- Invalid charset values are rejected at startup with a clear error.

## Related Issue

Closes #655

## Motivation and Context

Files like `robots.txt`, `llms.txt`, sitemaps emitted as `.txt`, plain READMEs, and markdown sources are served with a bare `text/plain` or `text/markdown` `Content-Type` and no charset parameter. Browsers fall back to a locale-specific guess (typically Windows-1252) and render any non-ASCII byte as mojibake — a UTF-8 em-dash `—` (`E2 80 94`) shows up as `â€"`. The only workaround today is to repeat `[[advanced.headers]]` entries in every project, which is verbose and easy to forget.

This PR mirrors the spirit of Apache's `AddDefaultCharset` and nginx's `charset` directive, but applies the annotation to every `text/*` subtype (Apache only covers `text/plain` and `text/html`, nginx requires an explicit `charset_types` list that excludes `text/markdown` and `text/css` by default). Defaulting to `utf-8` fixes the issue out of the box for the vast majority of modern static sites, while still allowing opt-out via an empty value for operators serving legacy encodings. 

Currently, I have to add a `sws.toml` to each of my project with, at least: 

```
[advanced]

[[advanced.headers]]
source = "**/*.txt"
headers = { Content-Type = "text/plain; charset=utf-8" }

[[advanced.headers]]
source = "**/*.md"
headers = { Content-Type = "text/markdown; charset=utf-8" }
```

## How Has This Been Tested?

- **Unit tests** in `src/text_charset.rs` cover the algorithm: annotation of bare `text/*`, preservation of existing `charset` (including unusual casing), non-text types ignored, disabled mode, missing `Content-Type`, unrelated parameters present, and tchar validation.
- **Integration tests** in `tests/text_charset.rs` exercise the wiring through the request pipeline: default behaviour, disabled via empty string, custom charset value, `[[advanced.headers]]` taking precedence, and startup-time rejection of invalid values.
- Existing assertions in `tests/compression.rs`, `tests/cors.rs`, `tests/handler.rs`, `tests/markdown.rs`, `tests/redirects.rs`, `tests/rewrites.rs` and `tests/compression_static.rs` were updated to reflect the new default.
- Full suite: `cargo test --all-features` is green; `cargo clippy --all-features --tests --lib --bins -- -D warnings` and `cargo fmt --check` are clean.