### PR TITLE
Improve MIME types for compression and default text charset features

### DIFF
--- a/docs/content/configuration/command-line-arguments.md
+++ b/docs/content/configuration/command-line-arguments.md
@@ -35,13 +35,13 @@ Options:
       --page404 <PAGE404>
           HTML file path for 404 errors. If the path is not specified or simply doesn't exist then the server will use a generic HTML error message. If a relative path is used then it will be resolved under the root directory [env: SERVER_ERROR_PAGE_404=] [default: ./404.html]
       --page-fallback <PAGE_FALLBACK>
-          A HTML file path (not relative to the root) used for GET requests when the requested path doesn't exist. The fallback page is served with a 200 status code, useful when using client routers. If the path doesn't exist then the feature is not activated [env: SERVER_FALLBACK_PAGE=] [default: ]
+          A HTML file path (not relative to the root) used for GET requests when the requested path doesn't exist. The fallback page is served with a 200 status code, useful when using client routers. If the path doesn't exist then the feature is not activated [env: SERVER_FALLBACK_PAGE=] [default: ""]
   -g, --log-level <LOG_LEVEL>
           Specify a logging level in lower case. Values: error, warn, info, debug or trace [env: SERVER_LOG_LEVEL=] [default: error]
       --log-with-ansi [<LOG_WITH_ANSI>]
           Enable or disable ANSI escape codes for colors and other text formatting of the log output [env: SERVER_LOG_WITH_ANSI=] [default: false] [possible values: true, false]
   -c, --cors-allow-origins <CORS_ALLOW_ORIGINS>
-          Specify an optional CORS list of allowed origin hosts separated by commas. Host ports or protocols aren't being checked. Use an asterisk (*) to allow any host [env: SERVER_CORS_ALLOW_ORIGINS=] [default: ]
+          Specify an optional CORS list of allowed origin hosts separated by commas. Host ports or protocols aren't being checked. Use an asterisk (*) to allow any host [env: SERVER_CORS_ALLOW_ORIGINS=] [default: ""]
   -j, --cors-allow-headers <CORS_ALLOW_HEADERS>
           Specify an optional CORS list of allowed headers separated by commas. Default "origin, content-type". It requires `--cors-allow-origins` to be used along with [env: SERVER_CORS_ALLOW_HEADERS=] [default: "origin, content-type, authorization"]
       --cors-expose-headers <CORS_EXPOSE_HEADERS>
@@ -81,7 +81,7 @@ Options:
   -e, --cache-control-headers [<CACHE_CONTROL_HEADERS>]
           Enable cache control headers for incoming requests based on a set of file types. The file type list can be found on `src/control_headers.rs` file [env: SERVER_CACHE_CONTROL_HEADERS=] [default: true] [possible values: true, false]
       --basic-auth <BASIC_AUTH>
-          It provides The "Basic" HTTP Authentication scheme using credentials as "user-id:password" pairs. Password must be encoded using the "BCrypt" password-hashing function [env: SERVER_BASIC_AUTH=] [default: ]
+          It provides The "Basic" HTTP Authentication scheme using credentials as "user-id:password" pairs. Password must be encoded using the "BCrypt" password-hashing function [env: SERVER_BASIC_AUTH=] [default: ""]
   -q, --grace-period <GRACE_PERIOD>
           Defines a grace period in seconds after a `SIGTERM` signal is caught which will delay the server before to shut it down gracefully. The maximum value is 255 seconds [env: SERVER_GRACE_PERIOD=] [default: 0]
   -w, --config-file <CONFIG_FILE>
@@ -97,21 +97,23 @@ Options:
       --redirect-trailing-slash [<REDIRECT_TRAILING_SLASH>]
           Check for a trailing slash in the requested directory URI and redirect permanently (308) to the same path with a trailing slash suffix if it is missing [env: SERVER_REDIRECT_TRAILING_SLASH=] [default: true] [possible values: true, false]
       --ignore-hidden-files [<IGNORE_HIDDEN_FILES>]
-          Ignore hidden files/directories (dotfiles), preventing them to be served and being included in auto HTML index pages (directory listing) [env: SERVER_IGNORE_HIDDEN_FILES=] [default: false] [possible values: true, false]
+          Ignore hidden files/directories (dotfiles), preventing them to be served and being included in auto HTML index pages (directory listing) [env: SERVER_IGNORE_HIDDEN_FILES=] [default: true] [possible values: true, false]
       --disable-symlinks [<DISABLE_SYMLINKS>]
-          Prevent following files or directories if any path name component is a symbolic link [env: SERVER_DISABLE_SYMLINKS=] [default: false] [possible values: true, false]
+          Prevent following files or directories if any path name component is a symbolic link [env: SERVER_DISABLE_SYMLINKS=] [default: true] [possible values: true, false]
+      --accept-markdown [<ACCEPT_MARKDOWN>]
+          Enable markdown content negotiation. When a client sends Accept: text/markdown, serve .md or .html.md files if available [env: SERVER_ACCEPT_MARKDOWN=] [default: false] [possible values: true, false]
+      --text-charset [<TEXT_CHARSET>]
+          Set a default `charset=utf-8` parameter on limited set of `text` responses that don't already have one [env: SERVER_TEXT_CHARSET=] [default: true] [possible values: true, false]
       --health [<HEALTH>]
           Add a /health endpoint that doesn't generate any log entry and returns a 200 status code. This is especially useful with Kubernetes liveness and readiness probes [env: SERVER_HEALTH=] [default: false] [possible values: true, false]
-      --accept-markdown [<ACCEPT_MARKDOWN>]
-          Enable markdown content negotiation. When a client sends Accept: text/markdown header, the server will serve markdown files (.md or .html.md) if available [env: SERVER_ACCEPT_MARKDOWN=] [default: false] [possible values: true, false]
-      --text-charset <TEXT_CHARSET>
-          Declare a default `charset` parameter on `text/*` responses that don't already have one. Set to empty to disable [env: SERVER_TEXT_CHARSET=] [default: utf-8]
+      --metrics [<METRICS>]
+          Enable the /metrics endpoint that exposes Prometheus metrics for HTTP requests, connections, and latency [env: SERVER_METRICS=] [default: false] [possible values: true, false]
       --maintenance-mode [<MAINTENANCE_MODE>]
           Enable the server's maintenance mode functionality [env: SERVER_MAINTENANCE_MODE=] [default: false] [possible values: true, false]
       --maintenance-mode-status <MAINTENANCE_MODE_STATUS>
           Provide a custom HTTP status code when entering into maintenance mode. Default 503 [env: SERVER_MAINTENANCE_MODE_STATUS=] [default: 503]
       --maintenance-mode-file <MAINTENANCE_MODE_FILE>
-          Provide a custom maintenance mode HTML file. If not provided then a generic message will be displayed [env: SERVER_MAINTENANCE_MODE_FILE=] [default: ]
+          Provide a custom maintenance mode HTML file. If not provided then a generic message will be displayed [env: SERVER_MAINTENANCE_MODE_FILE=] [default: ""]
   -V, --version
           Print version info and exit
   -h, --help

--- a/docs/content/features/compression.md
+++ b/docs/content/features/compression.md
@@ -24,21 +24,25 @@ SWS honors the qualities specified by the client to choose the algorithm. In cas
 
 ## MIME types compressed
 
-Compression is only applied to files with the MIME types listed below, indicating text and similarly well compressing formats. The asterisk `*` is a placeholder indicating an arbitrary MIME type part.
+Compression is only applied to files with the MIME types listed below, indicating text and similarly well compressing formats.
 
-```txt
-text/*
-*+xml
-*+json
-application/rtf
-application/javascript
-application/json
-application/xml
-font/ttf
-application/font-sfnt
-application/vnd.ms-fontobject
-application/wasm
-```
+- `text/*`
+- Application types that are essentially text/structured data.
+    - `application/csv`
+    - `application/graphql`
+    - `application/javascript`
+    - `application/json`
+    - `application/rtf`
+    - `application/sql`
+    - `application/x-yaml`
+    - `application/xml`
+    - `application/yaml`
+- Binary types that are not text but considered compressible.
+    - `application/wasm`
+    - `application/font-sfnt`
+    - `application/vnd.ms-fontobject`
+    - `image/x-icon`
+    - `image/vnd.microsoft.icon`
 
 ## Compression level
 

--- a/docs/content/features/text-charset.md
+++ b/docs/content/features/text-charset.md
@@ -1,17 +1,32 @@
-# Default Charset for Text Responses
+# Default UTF-8 Charset for Text-Based Responses
 
-**`SWS`** can declare a default `charset` parameter on every `text/*` response that doesn't already carry one, mirroring Apache's `AddDefaultCharset` and nginx's `charset` directives.
+**SWS** automatically appends a `charset=utf-8` parameter to the `Content-Type` header for a predefined list of text-based MIME types.
 
-Without this option, files like `robots.txt`, `llms.txt`, plain READMEs or any other `text/*` resource are served without a charset parameter, and browsers fall back to a locale-specific guess (typically Windows-1252) that mojibake-corrupts any non-ASCII byte.
+## Included MIME Types
 
-The option is enabled by default with `utf-8` and can be controlled by the string `--text-charset` option or the equivalent [SERVER_TEXT_CHARSET](./../configuration/environment-variables.md#server_text_charset) env. Pass an empty value to disable it.
+The `charset=utf-8` parameter will be added to responses with the following MIME types:
 
-## Behaviour
+- `application/atom+xml`
+- `application/rss+xml`
+- `text/calendar`
+- `text/csv`
+- `text/html`
+- `text/markdown`
+- `text/plain`
+- `text/xml`
 
-- Applies to every response whose `Content-Type` starts with `text/`.
-- Skipped when the response already carries a `charset` parameter (e.g. markdown content negotiation, error pages).
-- Non-text responses (`application/json`, `application/javascript`, images, archives) are never touched.
-- Custom headers configured under `[[advanced.headers]]` still win over this option, because they are applied after.
+For example, a `robots.txt` file will be served with the header: `Content-Type: text/plain; charset=utf-8`.
+
+## Rationale
+
+Without this default behavior, files like `robots.txt`, `llms.txt`, plain READMEs and other text-based resources are served without an explicit character encoding. When the charset is missing, browsers and HTTP clients fall back to outdated, locale-specific guesses (such as Windows-1252 or US-ASCII). This default guessing often results in mojibake—corrupting international symbols, accents, and non-ASCII characters.
+Forcing UTF-8 ensures reliable, cross-platform text rendering.
+
+The option is enabled by default and can be controlled by boolean `--text-charset` option or the equivalent [SERVER_TEXT_CHARSET](./../configuration/environment-variables.md#server_text_charset) env.
+
+!!! info "Custom HTTP Headers Take Precedence"
+
+    Users can turn off the default UTF-8 charset if wanted or use a [Custom HTTP Headers](./custom-http-headers.md) with glob patterns to selectively apply charset to specific files.
 
 ## Usage examples
 
@@ -22,16 +37,10 @@ static-web-server --root ./public
 # robots.txt is served as: Content-Type: text/plain; charset=utf-8
 ```
 
-Set a different charset:
-
-```sh
-static-web-server --root ./public --text-charset iso-8859-1
-```
-
 Disable the feature entirely:
 
 ```sh
-static-web-server --root ./public --text-charset ""
+static-web-server --root ./public --text-charset=false
 ```
 
 Equivalent configuration file:
@@ -39,12 +48,12 @@ Equivalent configuration file:
 ```toml
 [general]
 root = "./public"
-text-charset = "utf-8"
+text-charset = false
 ```
 
 Equivalent environment variable:
 
 ```sh
-export SERVER_TEXT_CHARSET=utf-8
+export SERVER_TEXT_CHARSET=false
 static-web-server --root ./public
 ```

--- a/docs/content/features/text-charset.md
+++ b/docs/content/features/text-charset.md
@@ -26,7 +26,7 @@ The option is enabled by default and can be controlled by boolean `--text-charse
 
 !!! info "Custom HTTP Headers Take Precedence"
 
-    Users can turn off the default UTF-8 charset if wanted or use a [Custom HTTP Headers](./custom-http-headers.md) with glob patterns to selectively apply charset to specific files.
+    Users can turn off the default UTF-8 charset if wanted or use [Custom HTTP Headers](./custom-http-headers.md) with glob patterns to selectively apply charset to specific files.
 
 ## Usage examples
 

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -24,7 +24,7 @@ use hyper::{
     Body, Method, Request, Response, StatusCode,
     header::{CONTENT_ENCODING, CONTENT_LENGTH},
 };
-use mime_guess::{Mime, mime};
+use mime_guess::Mime;
 use pin_project::pin_project;
 use std::pin::Pin;
 use std::task::{Context, Poll};
@@ -35,20 +35,9 @@ use crate::{
     handler::RequestHandlerOpts,
     headers_ext::{AcceptEncoding, ContentCoding},
     http_ext::MethodExt,
+    mime_ext::MimeExt,
     settings::CompressionLevel,
 };
-
-/// Contains a fixed list of common text-based MIME types that aren't recognizable in a generic way.
-const TEXT_MIME_TYPES: [&str; 8] = [
-    "application/rtf",
-    "application/javascript",
-    "application/json",
-    "application/xml",
-    "font/ttf",
-    "application/font-sfnt",
-    "application/vnd.ms-fontobject",
-    "application/wasm",
-];
 
 /// List of encodings that can be handled given enabled features.
 const AVAILABLE_ENCODINGS: &[ContentCoding] = &[
@@ -154,7 +143,7 @@ pub fn auto(
 
         // Skip compression for non-text-based MIME types
         if let Some(content_type) = resp.headers().typed_get::<ContentType>()
-            && !is_text(Mime::from(content_type))
+            && !Mime::from(content_type).is_compressible()
         {
             return Ok(resp);
         }
@@ -189,15 +178,6 @@ pub fn auto(
     }
 
     Ok(resp)
-}
-
-/// Checks whether the MIME type corresponds to any of the known text types.
-fn is_text(mime: Mime) -> bool {
-    mime.type_() == mime::TEXT
-        || mime
-            .suffix()
-            .is_some_and(|suffix| suffix == mime::XML || suffix == mime::JSON)
-        || TEXT_MIME_TYPES.contains(&mime.essence_str())
 }
 
 /// Create a wrapping handler that compresses the Body of a [`Response`].

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -125,9 +125,8 @@ pub struct RequestHandlerOpts {
     pub disable_symlinks: bool,
     /// Accept markdown content negotiation feature.
     pub accept_markdown: bool,
-    /// Default `charset` parameter applied to `text/*` responses without one.
-    /// Empty disables the feature.
-    pub text_charset: String,
+    /// Default `charset=utf-8` parameter applied to certain `text` responses without one.
+    pub text_charset: bool,
     /// Health endpoint feature.
     pub health: bool,
     /// Metrics endpoint feature.
@@ -186,7 +185,7 @@ impl Default for RequestHandlerOpts {
             ignore_hidden_files: false,
             disable_symlinks: false,
             accept_markdown: false,
-            text_charset: String::from("utf-8"),
+            text_charset: true,
             health: false,
             #[cfg(feature = "metrics")]
             metrics_enabled: false,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -185,6 +185,9 @@ pub mod winservice;
 #[macro_use]
 pub mod error;
 
+#[allow(dead_code)]
+pub(crate) mod mime_ext;
+
 // Private modules
 #[doc(hidden)]
 mod helpers;

--- a/src/mime_ext.rs
+++ b/src/mime_ext.rs
@@ -1,0 +1,213 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// This file is part of Static Web Server.
+// See https://static-web-server.net/ for more information
+// Copyright (C) 2019-present Jose Quintana <joseluisq.net>
+
+//! Module for providing MIME type extensions and utilities.
+//!
+
+use mime_guess::{Mime, mime};
+
+/// Application types that are essentially text/structured data.
+const TEXT_MIME_TYPES: [&str; 9] = [
+    "application/csv",
+    "application/graphql",
+    "application/javascript",
+    "application/json",
+    "application/rtf",
+    "application/sql",
+    "application/x-yaml",
+    "application/xml",
+    "application/yaml",
+];
+
+/// Binary types that are not "text" but considered compressible.
+const ADDITIONAL_COMPRESSIBLE_TYPES: [&str; 5] = [
+    "application/wasm",
+    "application/font-sfnt",
+    "application/vnd.ms-fontobject",
+    "image/x-icon",
+    "image/vnd.microsoft.icon",
+];
+
+pub(crate) trait MimeExt {
+    fn is_text(&self) -> bool;
+    fn is_text_only(&self) -> bool;
+    fn is_compressible(&self) -> bool;
+    fn contains_text_only(&self, allowed: &[&str]) -> bool;
+}
+
+impl MimeExt for Mime {
+    /// Determines if a MIME type is considered "text-only" and restricted to only `text/*` types.
+    fn is_text_only(&self) -> bool {
+        self.type_() == mime::TEXT
+    }
+
+    /// Determines if a MIME type is considered "text" based on its type and known characteristics.
+    /// Not restricted to `text/*` only but also includes types with text-like suffixes (e.g., `application/problem+json`) and known text-based formats.
+    fn is_text(&self) -> bool {
+        // text/*
+        if self.is_text_only() {
+            return true;
+        }
+
+        // Suffixes (e.g., application/problem+json)
+        if let Some(suffix) = self.suffix() {
+            let s = suffix.as_str();
+            if s == "json" || s == "xml" || s == "yaml" || s == "svg" {
+                return true;
+            }
+        }
+
+        TEXT_MIME_TYPES.contains(&self.essence_str())
+    }
+
+    /// Checks if the MIME type's essence matches any in the provided list, but only if it's a text-only type.
+    fn contains_text_only(&self, list: &[&str]) -> bool {
+        if !self.is_text_only() {
+            return false;
+        }
+        let s = self.essence_str();
+        list.contains(&s)
+    }
+
+    /// Determines if a MIME type is compressible based on its essence and known characteristics.
+    fn is_compressible(&self) -> bool {
+        let s = self.essence_str();
+
+        // Text is always compressible
+        if self.is_text() {
+            return true;
+        }
+
+        // Font handling (e.g. TTF/OTF/WOFF(1))
+        if self.type_() == mime::FONT {
+            // WOFF2 is already compressed
+            return s != "font/woff2";
+        }
+
+        // Known compressible binary formats
+        ADDITIONAL_COMPRESSIBLE_TYPES.contains(&s)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use mime_guess::Mime;
+
+    use super::MimeExt;
+
+    #[test]
+    fn test_is_text() {
+        for ext in super::TEXT_MIME_TYPES.iter() {
+            assert!(
+                ext.parse::<Mime>().unwrap().is_text(),
+                "'{ext}' should be considered text"
+            );
+        }
+        const OTHER_TEXT_TYPES: [&str; 7] = [
+            "application/problem+json",
+            "application/problem+xml",
+            "application/vnd.api+json",
+            "application/vnd.api+xml",
+            "image/svg+xml",
+            "text/calendar",
+            "text/csv",
+        ];
+        for ext in OTHER_TEXT_TYPES.iter() {
+            assert!(
+                ext.parse::<Mime>().unwrap().is_text(),
+                "'{ext}' should be considered text due to suffix"
+            );
+        }
+    }
+
+    #[test]
+    fn test_is_not_text() {
+        const NON_TEXT_TYPES: [&str; 5] = [
+            "application/font-woff2",
+            "application/octet-stream",
+            "application/wasm",
+            "font/ttf",
+            "image/png",
+        ];
+        for ext in NON_TEXT_TYPES.iter() {
+            assert!(
+                !ext.parse::<Mime>().unwrap().is_text(),
+                "'{}' should not be considered text",
+                ext
+            );
+        }
+    }
+
+    #[test]
+    fn test_is_compressible() {
+        for ext in super::TEXT_MIME_TYPES.iter() {
+            assert!(
+                ext.parse::<Mime>().unwrap().is_compressible(),
+                "'{ext}' should be considered compressible"
+            );
+        }
+        for ext in super::ADDITIONAL_COMPRESSIBLE_TYPES.iter() {
+            assert!(
+                ext.parse::<Mime>().unwrap().is_compressible(),
+                "'{ext}' should be considered compressible"
+            );
+        }
+    }
+
+    #[test]
+    fn test_is_not_compressible() {
+        const NON_COMPRESSIBLE_TYPES: [&str; 7] = [
+            "application/font-woff2",
+            "application/gzip",
+            "application/octet-stream",
+            "application/pdf",
+            "application/zip",
+            "image/jpeg",
+            "image/png",
+        ];
+
+        for ext in NON_COMPRESSIBLE_TYPES.iter() {
+            assert!(
+                !ext.parse::<Mime>().unwrap().is_compressible(),
+                "'{ext}' should not be compressible"
+            );
+        }
+    }
+
+    #[test]
+    fn test_is_text_only() {
+        const TEXT_ONLY_TYPES: [&str; 7] = [
+            "text/plain",
+            "text/csv",
+            "text/calendar",
+            "text/css",
+            "text/html",
+            "text/markdown",
+            "text/plain; boundary=x; charset=utf-8",
+        ];
+        for ext in TEXT_ONLY_TYPES.iter() {
+            assert!(
+                ext.parse::<Mime>().unwrap().is_text_only(),
+                "'{ext}' should be considered text-only"
+            );
+        }
+    }
+
+    #[test]
+    fn test_is_not_text_only() {
+        const NON_TEXT_ONLY_TYPES: [&str; 4] = [
+            "application/json",
+            "application/problem+json",
+            "application/xml",
+            "image/svg+xml",
+        ];
+        for ext in NON_TEXT_ONLY_TYPES.iter() {
+            assert!(
+                !ext.parse::<Mime>().unwrap().is_text_only(),
+                "'{ext}' should not be considered text-only"
+            );
+        }
+    }
+}

--- a/src/server.rs
+++ b/src/server.rs
@@ -268,11 +268,8 @@ impl Server {
         tracing::info!("disable symlinks: enabled={}", disable_symlinks);
 
         // Default charset for text/* responses
-        if general.text_charset.is_empty() {
-            tracing::info!("text charset: disabled");
-        } else {
-            tracing::info!("text charset: {}", general.text_charset);
-        }
+        let default_text_charset = general.text_charset;
+        tracing::info!("text charset: enabled={default_text_charset}");
 
         // Grace period option
         let grace_period = general.grace_period;

--- a/src/settings/cli.rs
+++ b/src/settings/cli.rs
@@ -512,9 +512,17 @@ pub struct General {
     /// Enable markdown content negotiation. When a client sends Accept: text/markdown, serve .md or .html.md files if available.
     pub accept_markdown: bool,
 
-    #[arg(long, default_value = "utf-8", env = "SERVER_TEXT_CHARSET")]
-    /// Declare a default `charset` parameter on `text/*` responses that don't already have one. Set to empty to disable.
-    pub text_charset: String,
+    #[arg(
+        long,
+        default_value = "true",
+        default_missing_value("true"),
+        num_args(0..=1),
+        require_equals(false),
+        action = clap::ArgAction::Set,
+        env = "SERVER_TEXT_CHARSET",
+    )]
+    /// Set a default `charset=utf-8` parameter on limited set of `text` responses that don't already have one.
+    pub text_charset: bool,
 
     #[arg(
         long,

--- a/src/settings/file.rs
+++ b/src/settings/file.rs
@@ -374,8 +374,8 @@ pub struct General {
     /// Accept markdown content negotiation feature.
     pub accept_markdown: Option<bool>,
 
-    /// Default `charset` parameter for `text/*` responses (empty disables).
-    pub text_charset: Option<String>,
+    /// Set a default `charset=utf-8` parameter for `text/*` responses.
+    pub text_charset: Option<bool>,
 
     #[cfg(feature = "metrics")]
     /// Metrics endpoint feature.

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -13,7 +13,7 @@ use hyper::StatusCode;
 use regex_lite::Regex;
 use std::path::{Path, PathBuf};
 
-use crate::{Context, Result, helpers, logger, text_charset};
+use crate::{Context, Result, helpers, logger};
 
 pub mod cli;
 #[doc(hidden)]
@@ -201,7 +201,7 @@ impl Settings {
         let mut ignore_hidden_files = opts.ignore_hidden_files;
         let mut disable_symlinks = opts.disable_symlinks;
         let mut accept_markdown = opts.accept_markdown;
-        let mut text_charset = opts.text_charset;
+        let mut default_text_charset = opts.text_charset;
         let mut index_files = opts.index_files;
         let mut health = opts.health;
 
@@ -398,7 +398,7 @@ impl Settings {
                     accept_markdown = v
                 }
                 if let Some(v) = general.text_charset {
-                    text_charset = v
+                    default_text_charset = v
                 }
                 #[cfg(feature = "metrics")]
                 if let Some(v) = general.metrics {
@@ -612,10 +612,6 @@ impl Settings {
             logger::init(log_level.as_str(), log_with_ansi)?;
         }
 
-        if !text_charset.is_empty() && !text_charset::is_valid_charset(&text_charset) {
-            bail!("invalid text-charset value: {text_charset:?}");
-        }
-
         Ok(Settings {
             general: General {
                 version,
@@ -687,7 +683,7 @@ impl Settings {
                 ignore_hidden_files,
                 disable_symlinks,
                 accept_markdown,
-                text_charset,
+                text_charset: default_text_charset,
                 index_files,
                 health,
                 #[cfg(feature = "metrics")]

--- a/src/text_charset.rs
+++ b/src/text_charset.rs
@@ -11,73 +11,53 @@ use hyper::{
     Body, Response,
     header::{CONTENT_TYPE, HeaderValue},
 };
+use mime_guess::{Mime, mime};
 
+use crate::mime_ext::MimeExt;
 use crate::{Error, handler::RequestHandlerOpts};
 
-/// Validates a charset value against the RFC 7230 `token` grammar.
-pub(crate) fn is_valid_charset(value: &str) -> bool {
-    !value.is_empty()
-        && value.bytes().all(|b| {
-            b.is_ascii_alphanumeric()
-                || matches!(
-                    b,
-                    b'!' | b'#'
-                        | b'$'
-                        | b'%'
-                        | b'&'
-                        | b'\''
-                        | b'*'
-                        | b'+'
-                        | b'-'
-                        | b'.'
-                        | b'^'
-                        | b'_'
-                        | b'`'
-                        | b'|'
-                        | b'~'
-                )
-        })
-}
+/// MIME types requiring an explicit `; charset=utf-8` header.
+///
+/// These mime types contain human-readable text but do not default to UTF-8.
+/// Forcing UTF-8 prevents broken symbols and accents on the client side.
+/// It also overrides obsolete fallbacks like US-ASCII or ISO-8859-1.
+const TEXT_ONLY_TYPES: [&str; 8] = [
+    "application/atom+xml",
+    "application/rss+xml",
+    "text/calendar",
+    "text/csv",
+    "text/html",
+    "text/markdown",
+    "text/plain",
+    "text/xml",
+];
 
-/// Adds `; charset=<value>` to the `Content-Type` header when the response
-/// type is `text/*` and no `charset` parameter is already present. A no-op
-/// when the option is disabled (empty value).
+/// Adds `; charset=utf-8` to the `Content-Type` header when the response
+/// type matches the  predefined list of `text` mime types and
+/// no `charset` parameter is already present.
 pub(crate) fn post_process(
     opts: &RequestHandlerOpts,
     mut resp: Response<Body>,
 ) -> Result<Response<Body>, Error> {
-    if opts.text_charset.is_empty() {
+    if !opts.text_charset {
         return Ok(resp);
     }
 
-    let ct = match resp
+    let new_header = resp
         .headers()
         .get(CONTENT_TYPE)
-        .and_then(|v| v.to_str().ok())
-    {
-        Some(v) if is_text(v) && !has_charset_param(v) => v,
-        _ => return Ok(resp),
-    };
+        .and_then(|h| h.to_str().ok())
+        .and_then(|s| s.parse::<Mime>().ok().map(|m| (s, m)))
+        .filter(|(_, m)| {
+            m.contains_text_only(&TEXT_ONLY_TYPES) && m.get_param(mime::CHARSET).is_none()
+        })
+        .map(|(s, _)| format!("{}; charset=utf-8", s.trim_end().trim_end_matches(';')))
+        .and_then(|s| HeaderValue::from_str(&s).ok());
 
-    if let Ok(value) = HeaderValue::from_str(&format!("{ct}; charset={}", opts.text_charset)) {
+    if let Some(value) = new_header {
         resp.headers_mut().insert(CONTENT_TYPE, value);
     }
     Ok(resp)
-}
-
-fn is_text(content_type: &str) -> bool {
-    content_type
-        .get(..5)
-        .is_some_and(|p| p.eq_ignore_ascii_case("text/"))
-}
-
-fn has_charset_param(content_type: &str) -> bool {
-    content_type.split(';').skip(1).any(|param| {
-        param
-            .trim_start()
-            .get(..8)
-            .is_some_and(|p| p.eq_ignore_ascii_case("charset="))
-    })
 }
 
 #[cfg(test)]
@@ -85,9 +65,9 @@ mod tests {
     use super::*;
     use hyper::Body;
 
-    fn opts(charset: &str) -> RequestHandlerOpts {
+    fn opts(text_charset: bool) -> RequestHandlerOpts {
         RequestHandlerOpts {
-            text_charset: charset.to_owned(),
+            text_charset,
             ..Default::default()
         }
     }
@@ -105,32 +85,32 @@ mod tests {
 
     #[test]
     fn annotates_bare_text_type() {
-        let r = post_process(&opts("utf-8"), resp_with("text/plain")).unwrap();
+        let r = post_process(&opts(true), resp_with("text/plain")).unwrap();
         assert_eq!(ct(&r), "text/plain; charset=utf-8");
     }
 
     #[test]
     fn annotates_text_markdown() {
-        let r = post_process(&opts("utf-8"), resp_with("text/markdown")).unwrap();
+        let r = post_process(&opts(true), resp_with("text/markdown")).unwrap();
         assert_eq!(ct(&r), "text/markdown; charset=utf-8");
     }
 
     #[test]
     fn preserves_existing_charset() {
-        let r = post_process(&opts("utf-8"), resp_with("text/html; charset=iso-8859-1")).unwrap();
+        let r = post_process(&opts(true), resp_with("text/html; charset=iso-8859-1")).unwrap();
         assert_eq!(ct(&r), "text/html; charset=iso-8859-1");
     }
 
     #[test]
     fn preserves_charset_with_unusual_casing_and_spacing() {
-        let r = post_process(&opts("utf-8"), resp_with("text/html;CHARSET=utf-8")).unwrap();
+        let r = post_process(&opts(true), resp_with("text/html;CHARSET=utf-8")).unwrap();
         assert_eq!(ct(&r), "text/html;CHARSET=utf-8");
     }
 
     #[test]
     fn preserves_charset_when_not_first_param() {
         let r = post_process(
-            &opts("utf-8"),
+            &opts(true),
             resp_with("text/plain; foo=bar; charset=latin1"),
         )
         .unwrap();
@@ -139,35 +119,25 @@ mod tests {
 
     #[test]
     fn ignores_non_text_type() {
-        let r = post_process(&opts("utf-8"), resp_with("application/json")).unwrap();
+        let r = post_process(&opts(true), resp_with("application/json")).unwrap();
         assert_eq!(ct(&r), "application/json");
     }
 
     #[test]
     fn ignores_when_disabled() {
-        let r = post_process(&opts(""), resp_with("text/plain")).unwrap();
+        let r = post_process(&opts(false), resp_with("text/plain")).unwrap();
         assert_eq!(ct(&r), "text/plain");
     }
 
     #[test]
     fn ignores_when_content_type_missing() {
-        let r = post_process(&opts("utf-8"), Response::new(Body::empty())).unwrap();
+        let r = post_process(&opts(true), Response::new(Body::empty())).unwrap();
         assert!(r.headers().get(CONTENT_TYPE).is_none());
     }
 
     #[test]
     fn appends_when_unrelated_param_present() {
-        let r = post_process(&opts("utf-8"), resp_with("text/plain; boundary=x")).unwrap();
+        let r = post_process(&opts(true), resp_with("text/plain; boundary=x")).unwrap();
         assert_eq!(ct(&r), "text/plain; boundary=x; charset=utf-8");
-    }
-
-    #[test]
-    fn validates_charset_tokens() {
-        assert!(is_valid_charset("utf-8"));
-        assert!(is_valid_charset("ISO-8859-1"));
-        assert!(is_valid_charset("windows-1252"));
-        assert!(!is_valid_charset(""));
-        assert!(!is_valid_charset("utf 8"));
-        assert!(!is_valid_charset("utf\"8"));
     }
 }

--- a/tests/compression_static.rs
+++ b/tests/compression_static.rs
@@ -244,7 +244,7 @@ mod tests {
                 assert_eq!(headers["accept-ranges"], "bytes");
                 assert!(!headers["last-modified"].is_empty());
                 assert_eq!(
-                    &headers["content-type"], "text/css; charset=utf-8",
+                    &headers["content-type"], "text/css",
                     "content-type is not css"
                 );
                 assert_eq!(headers["vary"], "accept-encoding");

--- a/tests/fixtures/toml/text_charset_custom.toml
+++ b/tests/fixtures/toml/text_charset_custom.toml
@@ -1,3 +1,0 @@
-[general]
-root = "tests/fixtures/markdown"
-text-charset = "iso-8859-1"

--- a/tests/fixtures/toml/text_charset_disabled.toml
+++ b/tests/fixtures/toml/text_charset_disabled.toml
@@ -1,3 +1,3 @@
 [general]
 root = "tests/fixtures/markdown"
-text-charset = ""
+text-charset = false

--- a/tests/rewrites.rs
+++ b/tests/rewrites.rs
@@ -128,10 +128,7 @@ pub mod tests {
         match req_handler.handle(&mut req, remote_addr).await {
             Ok(mut res) => {
                 assert_eq!(res.status(), 200);
-                assert_eq!(
-                    res.headers()["content-type"],
-                    "text/javascript; charset=utf-8"
-                );
+                assert_eq!(res.headers()["content-type"], "text/javascript");
 
                 let body = hyper::body::to_bytes(res.body_mut())
                     .await

--- a/tests/text_charset.rs
+++ b/tests/text_charset.rs
@@ -8,7 +8,6 @@ mod tests {
     use hyper::Request;
     use std::net::SocketAddr;
 
-    use static_web_server::Settings;
     use static_web_server::testing::fixtures::{
         REMOTE_ADDR, fixture_req_handler, fixture_req_handler_opts, fixture_settings,
     };
@@ -50,14 +49,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn custom_charset_is_applied() {
-        assert_eq!(
-            content_type("toml/text_charset_custom.toml", "http://localhost/doc.md").await,
-            "text/markdown; charset=iso-8859-1"
-        );
-    }
-
-    #[tokio::test]
     async fn advanced_headers_override_wins() {
         // [[advanced.headers]] runs after text_charset and is meant to win.
         assert_eq!(
@@ -67,19 +58,6 @@ mod tests {
             )
             .await,
             "text/html; charset=ascii"
-        );
-    }
-
-    #[test]
-    fn invalid_charset_value_is_rejected() {
-        let result = Settings::get_unparsed(
-            false,
-            &["static-web-server", "--text-charset", "utf 8 invalid"],
-        );
-        let err = result.err().expect("expected invalid charset to fail");
-        assert!(
-            err.to_string().contains("invalid text-charset"),
-            "unexpected error: {err}"
         );
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Read the docs/PULL_REQUESTS.md -->

## Description
<!--- Describe your changes but try to be as concise as possible -->

This improves the code internally regarding MIME types for the _dynamic compression_ and default _text charset_ features.

### Dynamic Compression

Added a wider range of MIME types to compress.

- Now, those MIME types will be compressed:
    - `text/*` types.
    - Application types that are essentially text/structured data.
        - `application/csv`
        - `application/graphql`
        - `application/javascript`
        - `application/json`
        - `application/rtf`
        - `application/sql`
        - `application/x-yaml`
        - `application/xml`
        - `application/yaml`
    - Binary types that are not `text` but considered compressible.
        -  `application/wasm`
        - `application/font-sfnt`
        - `application/vnd.ms-fontobject`
        - `image/x-icon`
        - `image/vnd.microsoft.icon`

### Default Text Charset (UTF-8)

This represents an improvement over the previous work done in #656. For more details, check out the PR module changes and the docs at `docs/content/features/text-charset.md`.

- The feature is now just a boolean.
- The chartset is now `charset=utf-8` only.
- An ad-hoc list with common text-based MIME types to match against it (smaller list).
    This was necessary because the previous implementation applied the charset to all `text/*` MIME types, but we do not want that for web MIME types like `text/css`, `text/javascript` and others.
    Now, only those MIME types will be affected:
    - `application/atom+xml`
    - `application/rss+xml`
    - `text/calendar`
    - `text/csv`
    - `text/html`
    - `text/markdown`
    - `text/plain`
    - `text/xml`
- Enforce UTF-8 only for those MIME types and let users provide their own if wanted via [Custom HTTP Headers](https://static-web-server.net/features/custom-http-headers/).
 
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- See how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
