### PR TITLE
Improve some server defaults

### DIFF
--- a/docs/content/features/cache-control-headers.md
+++ b/docs/content/features/cache-control-headers.md
@@ -8,24 +8,24 @@ This feature is enabled by default and can be controlled by the boolean `-e, --c
 
     If you want to customize HTTP headers on demand then have a look at the [Custom HTTP Headers](custom-http-headers.md) section.
 
-## Cache-Control Max-Age
+## Cache-Control
 
-Control headers are applied only to the following file types with the corresponding `max-age` values.
+Control headers are applied only to the following file types with the corresponding `max-age` values or `no-cache` directive (default).
 
-### One day
+### `no-cache` (default)
 
-A `max-age` of *one day* duration is used by default.
+A `no-cache` directive is used by default.
 
 !!! info "Note"
 
-    One-day `max-age` for example includes `html` and other file types.
+    `no-cache` applies to for example `HTML`, `JSON` and other file types.
 
 ### One hour
 
 A `max-age` of *one hour* is applied only to the following file types.
 
 ```txt
-atom, json, rss, xml
+atom, rss
 ```
 
 ### One year

--- a/docs/content/features/compression-static.md
+++ b/docs/content/features/compression-static.md
@@ -4,7 +4,7 @@
 
 SWS can look up existing pre-compressed file variants (`.gz`, `.br` or `.zst`) on disk and serve them directly.
 
-The feature is disabled by default and can be controlled by the boolean `--compression-static` option or the equivalent [SERVER_COMPRESSION_STATIC](./../configuration/environment-variables.md#server_compression_static) env.
+The feature is enabled by default and can be controlled by the boolean `--compression-static` option or the equivalent [SERVER_COMPRESSION_STATIC](./../configuration/environment-variables.md#server_compression_static) env.
 
 When the `compression-static` option is enabled and the pre-compressed file is found on the file system then it's served directly.
 Otherwise, if the pre-compressed file is not found then SWS just continues the normal workflow (trying to serve the original file requested instead). Additionally, if for example the [compression](../features/compression.md) option was also enabled then the requested file can be compressed on the fly right after.

--- a/docs/content/features/security-headers.md
+++ b/docs/content/features/security-headers.md
@@ -4,7 +4,7 @@
 
 When the [TLS](../features/tls.md) feature is activated *security headers* are enabled automatically.
 
-This feature is disabled by default on HTTP/1 and can be controlled by the boolean `--security-headers` option or the equivalent [SERVER_SECURITY_HEADERS](./../configuration/environment-variables.md#server_security_headers) env.
+This feature is enabled by default on HTTP/1 + HTTP/2 and can be controlled by the boolean `--security-headers` option or the equivalent [SERVER_SECURITY_HEADERS](./../configuration/environment-variables.md#server_security_headers) env.
 
 !!! tip "Customize HTTP headers"
 
@@ -14,7 +14,8 @@ This feature is disabled by default on HTTP/1 and can be controlled by the boole
 
 The following headers are included by default.
 
-- `Strict-Transport-Security: max-age=63072000; includeSubDomains; preload" (2 years max-age)`
+- `Strict-Transport-Security: max-age=63072000; includeSubDomains; preload` (2 years max-age)
 - `X-Frame-Options: DENY`
 - `X-Content-Type-Options: nosniff`
-- `Content-Security-Policy: frame-ancestors`
+- `Content-Security-Policy: frame-ancestors 'self'`
+- `Referrer-Policy: strict-origin-when-cross-origin`

--- a/src/control_headers.rs
+++ b/src/control_headers.rs
@@ -7,18 +7,21 @@
 //! for incoming requests based on a set of file types.
 //!
 
-use hyper::{Request, Response, header::HeaderValue};
+use hyper::{
+    Request, Response,
+    header::{CACHE_CONTROL, HeaderValue},
+};
 
 use crate::body::Body;
 use crate::{Error, handler::RequestHandlerOpts};
 
 // Pre-computed static Cache-Control header values
+static CACHE_CONTROL_DEFAULT: HeaderValue = HeaderValue::from_static("no-cache");
 static CACHE_CONTROL_ONE_HOUR: HeaderValue = HeaderValue::from_static("max-age=3600");
-static CACHE_CONTROL_ONE_DAY: HeaderValue = HeaderValue::from_static("max-age=86400");
 static CACHE_CONTROL_ONE_YEAR: HeaderValue = HeaderValue::from_static("max-age=31536000");
 
-// `Cache-Control` list of extensions
-const CACHE_EXT_ONE_HOUR: [&str; 4] = ["atom", "json", "rss", "xml"];
+// `Cache-Control` list of extensions (arrays must be alphabetically sorted)
+const CACHE_EXT_ONE_HOUR: [&str; 2] = ["atom", "rss"];
 const CACHE_EXT_ONE_YEAR: [&str; 32] = [
     "avif", "bmp", "bz2", "css", "doc", "gif", "gz", "htc", "ico", "jpeg", "jpg", "js", "jxl",
     "map", "mjs", "mp3", "mp4", "ogg", "ogv", "pdf", "png", "rar", "rtf", "tar", "tgz", "wav",
@@ -46,7 +49,7 @@ pub(crate) fn post_process<T>(
 pub fn append_headers(uri: &str, resp: &mut Response<Body>) {
     let header_value = get_cache_control_header(uri);
     resp.headers_mut()
-        .insert("cache-control", header_value.clone());
+        .insert(CACHE_CONTROL, header_value.clone());
 }
 
 /// Gets the file extension for a URI.
@@ -61,20 +64,67 @@ fn get_file_extension(uri: &str) -> Option<&str> {
 #[inline(always)]
 fn get_cache_control_header(uri: &str) -> &'static HeaderValue {
     if let Some(extension) = get_file_extension(uri) {
-        if CACHE_EXT_ONE_HOUR.binary_search(&extension).is_ok() {
-            return &CACHE_CONTROL_ONE_HOUR;
-        } else if CACHE_EXT_ONE_YEAR.binary_search(&extension).is_ok() {
-            return &CACHE_CONTROL_ONE_YEAR;
+        // Zero-allocation stack buffer optimization for lowercase conversion
+        let mut buf = [0u8; 16];
+        if extension.len() <= buf.len() {
+            let ext_bytes = &mut buf[..extension.len()];
+            ext_bytes.copy_from_slice(extension.as_bytes());
+            ext_bytes.make_ascii_lowercase();
+
+            if let Ok(ext_lower) = std::str::from_utf8(ext_bytes) {
+                if CACHE_EXT_ONE_HOUR.binary_search(&ext_lower).is_ok() {
+                    return &CACHE_CONTROL_ONE_HOUR;
+                } else if CACHE_EXT_ONE_YEAR.binary_search(&ext_lower).is_ok() {
+                    return &CACHE_CONTROL_ONE_YEAR;
+                }
+            }
+        } else {
+            // Fallback allocations for abnormally long extensions
+            let ext_lower = extension.to_ascii_lowercase();
+            if CACHE_EXT_ONE_HOUR
+                .binary_search(&ext_lower.as_str())
+                .is_ok()
+            {
+                return &CACHE_CONTROL_ONE_HOUR;
+            } else if CACHE_EXT_ONE_YEAR
+                .binary_search(&ext_lower.as_str())
+                .is_ok()
+            {
+                return &CACHE_CONTROL_ONE_YEAR;
+            }
         }
     }
-    &CACHE_CONTROL_ONE_DAY
+    &CACHE_CONTROL_DEFAULT
 }
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use hyper::{Response, StatusCode};
 
-    use super::{CACHE_EXT_ONE_HOUR, CACHE_EXT_ONE_YEAR, append_headers, get_file_extension};
+    #[test]
+    fn test_arrays_are_sorted() {
+        assert!(
+            CACHE_EXT_ONE_HOUR.windows(2).all(|w| w[0] < w[1]),
+            "CACHE_EXT_ONE_HOUR is not sorted!"
+        );
+        assert!(
+            CACHE_EXT_ONE_YEAR.windows(2).all(|w| w[0] < w[1]),
+            "CACHE_EXT_ONE_YEAR is not sorted!"
+        );
+    }
+
+    #[test]
+    fn headers_case_insensitivity() {
+        let mut resp = Response::new(crate::body::empty());
+        append_headers("/assets/script.JS", &mut resp);
+        let cache_control = resp.headers().get(CACHE_CONTROL).unwrap();
+        assert_eq!(cache_control.to_str().unwrap(), "max-age=31536000");
+
+        append_headers("/assets/IMAGE.PNG", &mut resp);
+        let cache_control = resp.headers().get(CACHE_CONTROL).unwrap();
+        assert_eq!(cache_control.to_str().unwrap(), "max-age=31536000");
+    }
 
     #[test]
     fn headers_one_hour() {
@@ -83,23 +133,39 @@ mod tests {
 
         for ext in CACHE_EXT_ONE_HOUR.iter() {
             append_headers(&["/some.", ext].concat(), &mut resp);
-
-            let cache_control = resp.headers().get(http::header::CACHE_CONTROL).unwrap();
-            assert_eq!(resp.status(), StatusCode::OK);
+            let cache_control = resp.headers().get(CACHE_CONTROL).unwrap();
             assert_eq!(cache_control.to_str().unwrap(), "max-age=3600");
         }
     }
 
     #[test]
-    fn headers_one_day_default() {
+    fn headers_default_fallback() {
         let mut resp = Response::new(crate::body::empty());
         *resp.status_mut() = StatusCode::OK;
 
         append_headers("/", &mut resp);
+        assert_eq!(
+            resp.headers().get(CACHE_CONTROL).unwrap().to_str().unwrap(),
+            "no-cache"
+        );
 
-        let cache_control = resp.headers().get(http::header::CACHE_CONTROL).unwrap();
-        assert_eq!(resp.status(), StatusCode::OK);
-        assert_eq!(cache_control.to_str().unwrap(), "max-age=86400");
+        append_headers("/index.html", &mut resp);
+        assert_eq!(
+            resp.headers().get(CACHE_CONTROL).unwrap().to_str().unwrap(),
+            "no-cache"
+        );
+
+        append_headers("/config.json", &mut resp);
+        assert_eq!(
+            resp.headers().get(CACHE_CONTROL).unwrap().to_str().unwrap(),
+            "no-cache"
+        );
+
+        append_headers("/api/data", &mut resp);
+        assert_eq!(
+            resp.headers().get(CACHE_CONTROL).unwrap().to_str().unwrap(),
+            "no-cache"
+        );
     }
 
     #[test]
@@ -109,17 +175,8 @@ mod tests {
 
         for ext in CACHE_EXT_ONE_YEAR.iter() {
             append_headers(&["/some.", ext].concat(), &mut resp);
-
-            let cache_control = resp.headers().get(http::header::CACHE_CONTROL).unwrap();
-            assert_eq!(resp.status(), StatusCode::OK);
+            let cache_control = resp.headers().get(CACHE_CONTROL).unwrap();
             assert_eq!(cache_control.to_str().unwrap(), "max-age=31536000");
         }
-    }
-
-    #[test]
-    fn find_uri_extension() {
-        assert_eq!(get_file_extension("/potato.zip"), Some("zip"));
-        assert_eq!(get_file_extension("/potato."), Some(""));
-        assert_eq!(get_file_extension("/"), None);
     }
 }

--- a/src/security_headers.rs
+++ b/src/security_headers.rs
@@ -20,6 +20,7 @@ static HSTS_VALUE: HeaderValue =
 static XFO_VALUE: HeaderValue = HeaderValue::from_static("DENY");
 static XCTO_VALUE: HeaderValue = HeaderValue::from_static("nosniff");
 static CSP_VALUE: HeaderValue = HeaderValue::from_static("frame-ancestors 'self'");
+static RP_VALUE: HeaderValue = HeaderValue::from_static("strict-origin-when-cross-origin");
 
 pub(crate) fn init(enabled: bool, handler_opts: &mut RequestHandlerOpts) {
     handler_opts.security_headers = enabled;
@@ -56,6 +57,10 @@ pub fn append_headers(resp: &mut Response<Body>) {
     // Content Security Policy (CSP)
     resp.headers_mut()
         .insert(CONTENT_SECURITY_POLICY, CSP_VALUE.clone());
+
+    // Referrer-Policy (RP)
+    resp.headers_mut()
+        .insert("referrer-policy", RP_VALUE.clone());
 }
 
 #[cfg(test)]
@@ -114,5 +119,14 @@ mod tests {
         assert!(resp.headers().contains_key(X_FRAME_OPTIONS));
         assert!(resp.headers().contains_key(X_CONTENT_TYPE_OPTIONS));
         assert!(resp.headers().contains_key(CONTENT_SECURITY_POLICY));
+    }
+
+    #[test]
+    fn append_headers_sets_referrer_policy() {
+        let mut resp = Response::new(crate::body::empty());
+        *resp.status_mut() = StatusCode::OK;
+        append_headers(&mut resp);
+        let rp = resp.headers().get("referrer-policy").unwrap();
+        assert_eq!(rp.to_str().unwrap(), "strict-origin-when-cross-origin");
     }
 }

--- a/src/settings/cli.rs
+++ b/src/settings/cli.rs
@@ -25,7 +25,7 @@ pub struct General {
     /// Host address (E.g 127.0.0.1 or ::1)
     pub host: String,
 
-    #[arg(long, short = 'p', default_value = "80", env = "SERVER_PORT")]
+    #[arg(long, short = 'p', default_value = "8787", env = "SERVER_PORT")]
     /// Host port
     pub port: u16,
 
@@ -300,7 +300,7 @@ pub struct General {
 
     #[arg(
         long,
-        default_value = "false",
+        default_value = "true",
         default_missing_value("true"),
         num_args(0..=1),
         require_equals(false),
@@ -371,7 +371,7 @@ pub struct General {
         feature = "tls",
         arg(
             long,
-            default_value = "false",
+            default_value = "true",
             default_missing_value("true"),
             num_args(0..=1),
             require_equals(false),

--- a/tests/compression.rs
+++ b/tests/compression.rs
@@ -61,7 +61,7 @@ pub mod tests {
                 );
                 assert_eq!(
                     res.headers().get("cache-control"),
-                    Some(&HeaderValue::from_static("max-age=86400"))
+                    Some(&HeaderValue::from_static("no-cache"))
                 );
                 assert_eq!(
                     res.headers().get("server"),

--- a/tests/handler.rs
+++ b/tests/handler.rs
@@ -89,7 +89,7 @@ pub mod tests {
 
                 assert_eq!(
                     res.headers().get("cache-control"),
-                    Some(&HeaderValue::from_static("max-age=86400"))
+                    Some(&HeaderValue::from_static("no-cache"))
                 );
                 assert_eq!(
                     res.headers().get("server"),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Read the docs/PULL_REQUESTS.md -->

## Description
<!--- Describe your changes but try to be as concise as possible -->

This PR improves the SWS defaults as follows.

- The `--port` is now `8787` (unprivileged).
- The `--compression-static` feature is now enabled by default.
- The `--security-headers` feature is now enabled by default.
- The `--cache-control` header logic is more pragmatic and less aggressive.

**Breaking changes**

For users running SWS default `80` (privileged) port, this represents a breaking change as it requires explicit adjustment (manual intervention).

**Security Headers**

- New `referrer-policy: strict-origin-when-cross-origin` header

**Cache-Control**

- The `no-cache` directive is used by default. This includes HTML, JSON, and others.
- A `max-age` of **one hour** is applied only to `atom`, `rss` file types.
- A `max-age` of **one year** is applied only to `avif, bmp, bz2, css, doc, gif, gz, htc, ico, jpeg, jpg, js, jxl, map, mjs, mp3, mp4, ogg, ogv, pdf, png, rar, rtf, tar, tgz, wav, weba, webm, webp, woff, woff2, zip`

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- See how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
