### PR TITLE
Stabilize In-memory Cache advanced feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,11 +38,11 @@ doc = false
 
 [features]
 # All features enabled by default
-default = ["compression", "http2", "tls-ring", "directory-listing", "directory-listing-download", "basic-auth", "fallback-page", "metrics"]
+default = ["compression", "http2", "tls-ring", "directory-listing", "directory-listing-download", "basic-auth", "fallback-page", "metrics", "mem-cache"]
 # Include all features (used when building SWS binaries)
 all = ["default", "experimental"]
 # Default feature set with the FIPS crypto provider in place of ring.
-default-fips = ["compression", "http2", "tls-fips", "directory-listing", "directory-listing-download", "basic-auth", "fallback-page", "metrics"]
+default-fips = ["compression", "http2", "tls-fips", "directory-listing", "directory-listing-download", "basic-auth", "fallback-page", "metrics", "mem-cache"]
 # All features with the FIPS crypto provider (used when building FIPS SWS binaries).
 all-fips = ["default-fips", "experimental"]
 # TLS base plumbing -- gates all TLS code via cfg(feature = "tls").
@@ -70,8 +70,10 @@ basic-auth = ["bcrypt"]
 fallback-page = []
 # Metrics endpoint with Prometheus integration
 metrics = ["prometheus"]
+# In-memory file cache with LFU admission and LRU eviction
+mem-cache = ["compact_str", "mini-moka"]
 # Experimental features (requires: `RUSTFLAGS="--cfg tokio_unstable"`)
-experimental = ["metrics", "tokio-metrics-collector", "compact_str", "mini-moka"]
+experimental = ["metrics", "tokio-metrics-collector"]
 
 [dependencies]
 aho-corasick = "1.1.4"

--- a/docs/content/building-from-source.md
+++ b/docs/content/building-from-source.md
@@ -30,7 +30,6 @@ However, you can disable just the ones you don't need from the lists below.
 | **Default** |  |
 | `default` | Activates the default features by omission. |
 | `all` | Activates all available features including the `experimental` feature. This is the default feature used when building SWS binaries. |
-| `experimental` | Activates all SWS experimental features. Make sure to also provide the required `RUSTFLAGS` if the feature requires so. |
 | [**HTTP2/TLS**](./features/http2-tls.md) |  |
 | `tls` | Activates the TLS feature. Requires exactly one of `tls-ring` or `tls-fips` to select a TLS crypto provider. |
 | `tls-ring` | Activates the TLS feature with [`ring`](https://github.com/briansmith/ring) as the TLS crypto provider. Included by default. |
@@ -48,6 +47,12 @@ However, you can disable just the ones you don't need from the lists below.
 | `basic-auth` | Activates the Basic HTTP Authorization Schema feature. |
 | [**Fallback Page**](./features/error-pages.md#fallback-page-for-use-with-client-routers) |  |
 | `fallback-page` | Activates the Fallback Page feature. |
+| [**Metrics**](./features/metrics.md) |  |
+| `metrics` | Activates the Prometheus metrics endpoint (`/metrics`). Enabled by default but requires the `--metrics` flag at runtime. |
+| [**In-Memory Cache**](./features/memory-cache.md) |  |
+| `mem-cache` | Activates the in-memory file cache with LFU admission and LRU eviction. Enabled by default. Configured via `[advanced.memory-cache]` in the TOML file. |
+| **Experimental** |  |
+| `experimental` | Activates all SWS experimental features (Tokio runtime metrics). Requires `RUSTFLAGS="--cfg tokio_unstable"`. |
 
 ### Disable all default features
 

--- a/docs/content/configuration/command-line-arguments.md
+++ b/docs/content/configuration/command-line-arguments.md
@@ -21,7 +21,7 @@ Options:
   -a, --host <HOST>
           Host address (E.g 127.0.0.1 or ::1) [env: SERVER_HOST=] [default: ::]
   -p, --port <PORT>
-          Host port [env: SERVER_PORT=] [default: 80]
+          Host port [env: SERVER_PORT=] [default: 8787]
   -f, --fd <FD>
           Instead of binding to a TCP port, accept incoming connections to an already-bound TCP socket listener on the specified file descriptor number (usually zero). Requires that the parent process (e.g. inetd, launchd, or systemd) binds an address and port on behalf of static-web-server, before arranging for the resulting file descriptor to be inherited by static-web-server. Cannot be used in conjunction with the port and host arguments. The included systemd unit file utilises this feature to increase security by allowing the static-web-server to be sandboxed more completely [env: SERVER_LISTEN_FD=]
   -n, --threads-multiplier <THREADS_MULTIPLIER>
@@ -35,27 +35,29 @@ Options:
       --page404 <PAGE404>
           HTML file path for 404 errors. If the path is not specified or simply doesn't exist then the server will use a generic HTML error message. If a relative path is used then it will be resolved under the root directory [env: SERVER_ERROR_PAGE_404=] [default: ./404.html]
       --page-fallback <PAGE_FALLBACK>
-          A HTML file path (not relative to the root) used for GET requests when the requested path doesn't exist. The fallback page is served with a 200 status code, useful when using client routers. If the path doesn't exist then the feature is not activated [env: SERVER_FALLBACK_PAGE=] [default: ]
+          A HTML file path (not relative to the root) used for GET requests when the requested path doesn't exist. The fallback page is served with a 200 status code, useful when using client routers. If the path doesn't exist then the feature is not activated [env: SERVER_FALLBACK_PAGE=] [default: ""]
   -g, --log-level <LOG_LEVEL>
           Specify a logging level in lower case. Values: error, warn, info, debug or trace [env: SERVER_LOG_LEVEL=] [default: error]
       --log-with-ansi [<LOG_WITH_ANSI>]
           Enable or disable ANSI escape codes for colors and other text formatting of the log output [env: SERVER_LOG_WITH_ANSI=] [default: false] [possible values: true, false]
   -c, --cors-allow-origins <CORS_ALLOW_ORIGINS>
-          Specify an optional CORS list of allowed origin hosts separated by commas. Host ports or protocols aren't being checked. Use an asterisk (*) to allow any host [env: SERVER_CORS_ALLOW_ORIGINS=] [default: ]
+          Specify an optional CORS list of allowed origin hosts separated by commas. Host ports or protocols aren't being checked. Use an asterisk (*) to allow any host [env: SERVER_CORS_ALLOW_ORIGINS=] [default: ""]
   -j, --cors-allow-headers <CORS_ALLOW_HEADERS>
           Specify an optional CORS list of allowed headers separated by commas. Default "origin, content-type". It requires `--cors-allow-origins` to be used along with [env: SERVER_CORS_ALLOW_HEADERS=] [default: "origin, content-type, authorization"]
       --cors-expose-headers <CORS_EXPOSE_HEADERS>
           Specify an optional CORS list of exposed headers separated by commas. Default "origin, content-type". It requires `--cors-expose-origins` to be used along with [env: SERVER_CORS_EXPOSE_HEADERS=] [default: "origin, content-type"]
-  -t, --http2 [<HTTP2>]
-          Enable HTTP/2 with TLS support [env: SERVER_HTTP2_TLS=] [default: false] [possible values: true, false]
-      --http2-tls-cert <HTTP2_TLS_CERT>
-          Specify the file path to read the certificate [env: SERVER_HTTP2_TLS_CERT=]
-      --http2-tls-key <HTTP2_TLS_KEY>
-          Specify the file path to read the private key [env: SERVER_HTTP2_TLS_KEY=]
+  -t, --tls [<TLS>]
+          Enable TLS/HTTPS support. Requires --tls-cert and --tls-key [env: SERVER_TLS=] [default: false] [possible values: true, false]
+      --tls-cert <TLS_CERT>
+          Specify the file path to the TLS certificate [env: SERVER_TLS_CERT=]
+      --tls-key <TLS_KEY>
+          Specify the file path to the TLS private key [env: SERVER_TLS_KEY=]
+      --http2 [<HTTP2>]
+          Enable HTTP/2 protocol support. Requires TLS to be enabled (--tls) [env: SERVER_HTTP2=] [default: false] [possible values: true, false]
       --https-redirect [<HTTPS_REDIRECT>]
-          Redirect all requests with scheme "http" to "https" for the current server instance. It depends on "http2" to be enabled [env: SERVER_HTTPS_REDIRECT=] [default: false] [possible values: true, false]
+          Redirect all requests with scheme "http" to "https" for the current server instance. Requires TLS to be enabled (--tls) [env: SERVER_HTTPS_REDIRECT=] [default: false] [possible values: true, false]
       --https-redirect-host <HTTPS_REDIRECT_HOST>
-          Canonical host name or IP of the HTTPS (HTTPS/2) server. It depends on "https_redirect" to be enabled [env: SERVER_HTTPS_REDIRECT_HOST=] [default: localhost]
+          Canonical host name or IP of the HTTPS server. It depends on "https_redirect" to be enabled [env: SERVER_HTTPS_REDIRECT_HOST=] [default: localhost]
       --https-redirect-from-port <HTTPS_REDIRECT_FROM_PORT>
           HTTP host port where the redirect server will listen for requests to redirect them to HTTPS. It depends on "https_redirect" to be enabled [env: SERVER_HTTPS_REDIRECT_FROM_PORT=] [default: 80]
       --https-redirect-from-hosts <HTTPS_REDIRECT_FROM_HOSTS>
@@ -67,7 +69,7 @@ Options:
       --compression-level <COMPRESSION_LEVEL>
           Compression level to apply for Gzip, Deflate, Brotli or Zstd compression [env: SERVER_COMPRESSION_LEVEL=] [default: default] [possible values: fastest, best, default]
       --compression-static [<COMPRESSION_STATIC>]
-          Look up the pre-compressed file variant (`.gz`, `.br` or `.zst`) on disk of a requested file and serves it directly if available. The compression type is determined by the `Accept-Encoding` header [env: SERVER_COMPRESSION_STATIC=] [default: false] [possible values: true, false]
+          Look up the pre-compressed file variant (`.gz`, `.br` or `.zst`) on disk of a requested file and serves it directly if available. The compression type is determined by the `Accept-Encoding` header [env: SERVER_COMPRESSION_STATIC=] [default: true] [possible values: true, false]
   -z, --directory-listing [<DIRECTORY_LISTING>]
           Enable directory listing for all requests ending with the slash character (‘/’) [env: SERVER_DIRECTORY_LISTING=] [default: false] [possible values: true, false]
       --directory-listing-order <DIRECTORY_LISTING_ORDER>
@@ -77,11 +79,11 @@ Options:
       --directory-listing-download=<DIRECTORY_LISTING_DOWNLOAD>
           Specify list of enabled format(s) for directory download. Format supported: `targz`. Default to empty list (disabled) [env: SERVER_DIRECTORY_LISTING_DOWNLOAD=] [possible values: targz]
       --security-headers [<SECURITY_HEADERS>]
-          Enable security headers by default when HTTP/2 feature is activated. Headers included: "Strict-Transport-Security: max-age=63072000; includeSubDomains; preload" (2 years max-age), "X-Frame-Options: DENY" and "Content-Security-Policy: frame-ancestors 'self'" [env: SERVER_SECURITY_HEADERS=] [default: false] [possible values: true, false]
+          Enable security headers by default when TLS feature is activated. Headers included: "Strict-Transport-Security: max-age=63072000; includeSubDomains; preload" (2 years max-age), "X-Frame-Options: DENY" and "Content-Security-Policy: frame-ancestors 'self'" [env: SERVER_SECURITY_HEADERS=] [default: true] [possible values: true, false]
   -e, --cache-control-headers [<CACHE_CONTROL_HEADERS>]
           Enable cache control headers for incoming requests based on a set of file types. The file type list can be found on `src/control_headers.rs` file [env: SERVER_CACHE_CONTROL_HEADERS=] [default: true] [possible values: true, false]
       --basic-auth <BASIC_AUTH>
-          It provides The "Basic" HTTP Authentication scheme using credentials as "user-id:password" pairs. Password must be encoded using the "BCrypt" password-hashing function [env: SERVER_BASIC_AUTH=] [default: ]
+          It provides The "Basic" HTTP Authentication scheme using credentials as "user-id:password" pairs. Password must be encoded using the "BCrypt" password-hashing function [env: SERVER_BASIC_AUTH=] [default: ""]
   -q, --grace-period <GRACE_PERIOD>
           Defines a grace period in seconds after a `SIGTERM` signal is caught which will delay the server before to shut it down gracefully. The maximum value is 255 seconds [env: SERVER_GRACE_PERIOD=] [default: 0]
   -w, --config-file <CONFIG_FILE>
@@ -97,21 +99,23 @@ Options:
       --redirect-trailing-slash [<REDIRECT_TRAILING_SLASH>]
           Check for a trailing slash in the requested directory URI and redirect permanently (308) to the same path with a trailing slash suffix if it is missing [env: SERVER_REDIRECT_TRAILING_SLASH=] [default: true] [possible values: true, false]
       --ignore-hidden-files [<IGNORE_HIDDEN_FILES>]
-          Ignore hidden files/directories (dotfiles), preventing them to be served and being included in auto HTML index pages (directory listing) [env: SERVER_IGNORE_HIDDEN_FILES=] [default: false] [possible values: true, false]
+          Ignore hidden files/directories (dotfiles), preventing them to be served and being included in auto HTML index pages (directory listing) [env: SERVER_IGNORE_HIDDEN_FILES=] [default: true] [possible values: true, false]
       --disable-symlinks [<DISABLE_SYMLINKS>]
-          Prevent following files or directories if any path name component is a symbolic link [env: SERVER_DISABLE_SYMLINKS=] [default: false] [possible values: true, false]
+          Prevent following files or directories if any path name component is a symbolic link [env: SERVER_DISABLE_SYMLINKS=] [default: true] [possible values: true, false]
+      --accept-markdown [<ACCEPT_MARKDOWN>]
+          Enable markdown content negotiation. When a client sends Accept: text/markdown, serve .md or .html.md files if available [env: SERVER_ACCEPT_MARKDOWN=] [default: false] [possible values: true, false]
+      --text-charset [<TEXT_CHARSET>]
+          Set a default `charset=utf-8` parameter on limited set of `text` responses that don't already have one [env: SERVER_TEXT_CHARSET=] [default: true] [possible values: true, false]
       --health [<HEALTH>]
           Add a /health endpoint that doesn't generate any log entry and returns a 200 status code. This is especially useful with Kubernetes liveness and readiness probes [env: SERVER_HEALTH=] [default: false] [possible values: true, false]
-      --accept-markdown [<ACCEPT_MARKDOWN>]
-          Enable markdown content negotiation. When a client sends Accept: text/markdown header, the server will serve markdown files (.md or .html.md) if available [env: SERVER_ACCEPT_MARKDOWN=] [default: false] [possible values: true, false]
-      --text-charset [<TEXT_CHARSET>]
-          Set a default charset=utf-8 parameter on limited set of text responses that don't already have one [env: SERVER_TEXT_CHARSET=] [default: true] [possible values: true, false]
+      --metrics [<METRICS>]
+          Enable the /metrics endpoint that exposes Prometheus metrics for HTTP requests, connections, and latency [env: SERVER_METRICS=] [default: false] [possible values: true, false]
       --maintenance-mode [<MAINTENANCE_MODE>]
           Enable the server's maintenance mode functionality [env: SERVER_MAINTENANCE_MODE=] [default: false] [possible values: true, false]
       --maintenance-mode-status <MAINTENANCE_MODE_STATUS>
           Provide a custom HTTP status code when entering into maintenance mode. Default 503 [env: SERVER_MAINTENANCE_MODE_STATUS=] [default: 503]
       --maintenance-mode-file <MAINTENANCE_MODE_FILE>
-          Provide a custom maintenance mode HTML file. If not provided then a generic message will be displayed [env: SERVER_MAINTENANCE_MODE_FILE=] [default: ]
+          Provide a custom maintenance mode HTML file. If not provided then a generic message will be displayed [env: SERVER_MAINTENANCE_MODE_FILE=] [default: ""]
   -V, --version
           Print version info and exit
   -h, --help

--- a/docs/content/configuration/config-file.md
+++ b/docs/content/configuration/config-file.md
@@ -172,6 +172,12 @@ maintenance-mode = false
 # [[advanced.virtual-hosts]]
 # host = "blog.example.com"
 # root = "/var/blog/html"
+
+# [advanced.memory-cache]
+# capacity = 100
+# ttl = 1800      # 30 minutes
+# tti = 300       # 5 minutes
+# max-file-size = 8192  # 8 MiB
 ```
 
 ### General options
@@ -188,7 +194,7 @@ So they are equivalent to each other **except** for the `-w, --config-file` opti
 
 The TOML `[advanced]` section is intended for more complex features.
 
-For example [Custom HTTP Headers](../features/custom-http-headers.md), [Custom URL Redirects](../features/url-redirects.md), [URL Rewrites](../features/url-rewrites.md), or [Virtual Hosting](../features/virtual-hosting.md)
+For example [Custom HTTP Headers](../features/custom-http-headers.md), [Custom URL Redirects](../features/url-redirects.md), [URL Rewrites](../features/url-rewrites.md), [Virtual Hosting](../features/virtual-hosting.md), or [In-Memory Cache](../features/memory-cache.md).
 
 ### Precedence
 

--- a/docs/content/features/memory-cache.md
+++ b/docs/content/features/memory-cache.md
@@ -41,7 +41,7 @@ max-file-size = 8192
 | `capacity`       | `u64` | 100     | 100 000    | entries   | Maximum number of cached file entries.                         |
 | `ttl`            | `u64` | 1800    | 86 400     | seconds   | Time-to-Live: maximum age of a cached entry before eviction.   |
 | `tti`            | `u64` | 300     | 3 600      | seconds   | Time-to-Idle: maximum idle time before an entry is evicted.    |
-| `max-file-size`  | `u64` | 8192    | 262 144    | KiB       | Maximum file size allowed into the cache. Files exceeding this limit are served from disk. |
+| `max-file-size`  | `u64` | 8192    | 32 768     | KiB       | Maximum file size allowed into the cache. Files exceeding this limit are served from disk. |
 
 !!! warning "Defaults & Limits"
     Values exceeding the maximum limits are clamped silently. For example, setting `capacity = 200000` results in `100000`.
@@ -50,7 +50,7 @@ max-file-size = 8192
 
 1. **First request**: SWS reads the file from disk, streams the response to the client, and simultaneously populates the cache store.
 2. **Subsequent requests** (within TTL/TTI): SWS serves the response directly from memory — zero disk I/O.
-3. **Concurrent misses**: A single-flight semaphore serializes concurrent cache misses, ensuring the file is read from disk only once per key.
+3. **Concurrent misses**: The underlying cache store is fully concurrent and thread-safe. Brief duplicate reads under contention are benign and resolve themselves once the entry is populated.
 4. **Eviction**: Entries that exceed TTL, idle beyond TTI, or are displaced by the LFU/LRU policies are evicted automatically.
 
 !!! tip "Pair with static compression"
@@ -59,8 +59,29 @@ max-file-size = 8192
 !!! note "Partial content (range requests)"
     Byte-range requests (`Range` header) are supported. The cache stores the whole file; partial responses are sliced from the cached bytes on every request.
 
+## X-Cache response header
+
+When a response is served from the in-memory cache, SWS includes the standard **`X-Cache: HIT`** header. This is the same header used by nginx, Apache, Varnish, and most CDNs to indicate cache status.
+
+- **Cache hit** — the response includes `X-Cache: HIT`.
+- **Cache miss** (first request, or cache disabled) — the `X-Cache` header is **not present**.
+
+You can use this header to verify cache behaviour via `curl`:
+
+```sh
+# First request (miss — no X-Cache header):
+curl -sI http://localhost:8787/index.html | grep -i x-cache
+# (no output)
+
+# Second request (hit — X-Cache: HIT):
+curl -sI http://localhost:8787/index.html | grep -i x-cache
+# x-cache: HIT
+```
+
+Or inspect it in browser developer tools under the **Network → Response Headers** tab.
+
 ## Performance considerations
 
 - For **small, frequently accessed files** (favicons, CSS, JS, HTML), enable the cache with a moderate `max-file-size` (e.g., 8192 KiB) and a long TTL (e.g., 3600s).
 - For **large files** (video, archives), keep `max-file-size` low or disable the cache entirely — serving large files from memory can increase RSS significantly.
-- The single-flight mechanism prevents **thundering herd** problems on cache misses, making the cache safe for high-concurrency workloads.
+- The cache store is lock-free for reads and uses fine-grained internal sharding for writes, so it scales well under high concurrency without blocking other requests.

--- a/docs/content/features/memory-cache.md
+++ b/docs/content/features/memory-cache.md
@@ -36,14 +36,15 @@ max-file-size = 8192
 
 ### Fields
 
-| Field            | Type  | Default | Maximum    | Unit      | Description                                                    |
-|------------------|-------|---------|------------|-----------|----------------------------------------------------------------|
-| `capacity`       | `u64` | 100     | 100 000    | entries   | Maximum number of cached file entries.                         |
-| `ttl`            | `u64` | 1800    | 86 400     | seconds   | Time-to-Live: maximum age of a cached entry before eviction.   |
-| `tti`            | `u64` | 300     | 3 600      | seconds   | Time-to-Idle: maximum idle time before an entry is evicted.    |
-| `max-file-size`  | `u64` | 8192    | 32 768     | KiB       | Maximum file size allowed into the cache. Files exceeding this limit are served from disk. |
+| Field | Type | Default | Maximum | Unit | Description |
+| -- | -- | -- | -- | -- | -- |
+| `capacity` | `u64` | 100 | 100 000 | entries | Maximum number of cached file entries. |
+| `ttl` | `u64` | 1800 | 86 400 | seconds | Time-to-Live: maximum age of a cached entry before eviction. |
+| `tti` | `u64` | 300 | 3 600 | seconds | Time-to-Idle: maximum idle time before an entry is evicted. |
+| `max-file-size` | `u64` | 8192 | 32 768 | KiB | Maximum file size allowed into the cache. Files exceeding this limit are served from disk. |
 
 !!! warning "Defaults & Limits"
+
     Values exceeding the maximum limits are clamped silently. For example, setting `capacity = 200000` results in `100000`.
 
 ## How it works
@@ -54,9 +55,11 @@ max-file-size = 8192
 4. **Eviction**: Entries that exceed TTL, idle beyond TTI, or are displaced by the LFU/LRU policies are evicted automatically.
 
 !!! tip "Pair with static compression"
+
     The in-memory cache stores **uncompressed** file data. It is safe to combine with [on-the-fly compression](compression.md) and [pre-compressed file serving](compression-static.md) — the cache lookup happens before compression in the request pipeline.
 
 !!! note "Partial content (range requests)"
+
     Byte-range requests (`Range` header) are supported. The cache stores the whole file; partial responses are sliced from the cached bytes on every request.
 
 ## X-Cache response header

--- a/docs/content/features/memory-cache.md
+++ b/docs/content/features/memory-cache.md
@@ -1,0 +1,66 @@
+# In-Memory Cache
+
+**`SWS`** provides an optional file-level in-memory cache that stores hot files in RAM, serving them directly without touching the filesystem on repeat requests.
+
+The cache uses a **Least Frequently Used (LFU)** admission policy and a **Least Recently Used (LRU)** eviction policy. Every entry has a **Time-to-Live (TTL)** and a **Time-to-Idle (TTI)** — expired or idle entries are evicted automatically.
+
+This feature is **enabled by default** via the `mem-cache` Cargo feature and configured entirely through the TOML configuration file.
+
+## Cargo Feature
+
+The in-memory cache is gated by the `mem-cache` Cargo feature, which is included in the `default` feature set.
+
+To **disable** it, build without default features and select only what you need:
+
+```sh
+cargo build --release --no-default-features \
+  --features "compression,http2,tls-ring,directory-listing,fallback-page,basic-auth,metrics"
+```
+
+Omitting `mem-cache` removes the `compact_str` and `mini-moka` dependencies from the binary.
+
+## Configuration
+
+Add the `[advanced.memory-cache]` section to your TOML configuration file. All fields are optional and will fall back to their defaults if omitted.
+
+```toml
+[advanced.memory-cache]
+capacity = 100
+# 30min
+ttl = 1800
+# 5min
+tti = 300
+# 8mb
+max-file-size = 8192
+```
+
+### Fields
+
+| Field            | Type  | Default | Maximum    | Unit      | Description                                                    |
+|------------------|-------|---------|------------|-----------|----------------------------------------------------------------|
+| `capacity`       | `u64` | 100     | 100 000    | entries   | Maximum number of cached file entries.                         |
+| `ttl`            | `u64` | 1800    | 86 400     | seconds   | Time-to-Live: maximum age of a cached entry before eviction.   |
+| `tti`            | `u64` | 300     | 3 600      | seconds   | Time-to-Idle: maximum idle time before an entry is evicted.    |
+| `max-file-size`  | `u64` | 8192    | 262 144    | KiB       | Maximum file size allowed into the cache. Files exceeding this limit are served from disk. |
+
+!!! warning "Defaults & Limits"
+    Values exceeding the maximum limits are clamped silently. For example, setting `capacity = 200000` results in `100000`.
+
+## How it works
+
+1. **First request**: SWS reads the file from disk, streams the response to the client, and simultaneously populates the cache store.
+2. **Subsequent requests** (within TTL/TTI): SWS serves the response directly from memory — zero disk I/O.
+3. **Concurrent misses**: A single-flight semaphore serializes concurrent cache misses, ensuring the file is read from disk only once per key.
+4. **Eviction**: Entries that exceed TTL, idle beyond TTI, or are displaced by the LFU/LRU policies are evicted automatically.
+
+!!! tip "Pair with static compression"
+    The in-memory cache stores **uncompressed** file data. It is safe to combine with [on-the-fly compression](compression.md) and [pre-compressed file serving](compression-static.md) — the cache lookup happens before compression in the request pipeline.
+
+!!! note "Partial content (range requests)"
+    Byte-range requests (`Range` header) are supported. The cache stores the whole file; partial responses are sliced from the cached bytes on every request.
+
+## Performance considerations
+
+- For **small, frequently accessed files** (favicons, CSS, JS, HTML), enable the cache with a moderate `max-file-size` (e.g., 8192 KiB) and a long TTL (e.g., 3600s).
+- For **large files** (video, archives), keep `max-file-size` low or disable the cache entirely — serving large files from memory can increase RSS significantly.
+- The single-flight mechanism prevents **thundering herd** problems on cache misses, making the cache safe for high-concurrency workloads.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -167,6 +167,7 @@ nav:
     - 'Virtual Hosting': 'features/virtual-hosting.md'
     - 'Multiple Index Files': 'features/multiple-index-files.md'
     - 'Maintenance Mode': 'features/maintenance-mode.md'
+    - 'In-Memory Cache': 'features/memory-cache.md'
     - 'WebAssembly': 'features/webassembly.md'
     - 'Man Pages and Shell Completions': 'features/man-pages-completions.md'
     - 'Markdown Content Negotiation': 'features/markdown-content-negotiation.md'

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -36,7 +36,7 @@ use crate::fallback_page;
 #[cfg(feature = "metrics")]
 use crate::metrics;
 
-#[cfg(feature = "experimental")]
+#[cfg(feature = "mem-cache")]
 use crate::mem_cache::cache::MemCacheOpts;
 
 use crate::{
@@ -59,8 +59,8 @@ pub struct RequestHandlerOpts {
     // General options
     /// Root directory of static files.
     pub root_dir: PathBuf,
-    #[cfg(feature = "experimental")]
-    /// In-memory cache feature (experimental).
+    #[cfg(feature = "mem-cache")]
+    /// In-memory cache feature.
     pub memory_cache: Option<MemCacheOpts>,
     /// Compression feature.
     pub compression: bool,
@@ -168,7 +168,7 @@ impl Default for RequestHandlerOpts {
             #[cfg(feature = "directory-listing-download")]
             dir_listing_download: Vec::new(),
             cors: None,
-            #[cfg(feature = "experimental")]
+            #[cfg(feature = "mem-cache")]
             memory_cache: None,
             security_headers: false,
             cache_control_headers: true,
@@ -229,7 +229,7 @@ impl RequestHandler {
         let ignore_hidden_files = self.opts.ignore_hidden_files;
         let disable_symlinks = self.opts.disable_symlinks;
         let index_files: Vec<&str> = self.opts.index_files.iter().map(|s| s.as_str()).collect();
-        #[cfg(feature = "experimental")]
+        #[cfg(feature = "mem-cache")]
         let memory_cache = self.opts.memory_cache.as_ref();
 
         log_addr::pre_process(&self.opts, req, remote_addr);
@@ -318,7 +318,7 @@ impl RequestHandler {
                 let (resp, file_path) = match static_files::handle(&HandleOpts {
                     method: req.method(),
                     headers: req.headers(),
-                    #[cfg(feature = "experimental")]
+                    #[cfg(feature = "mem-cache")]
                     memory_cache,
                     base_path,
                     uri_path,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,7 +77,7 @@
 //! **Default** |
 //! `default` | Activates the default features.
 //! `all` | Activates all features including the default and experimental ones. E.g. this feature is used when building the SWS binaries.
-//! `experimental` | Activates all unstable features.
+//! `experimental` | Activates all unstable features (tokio runtime metrics).
 //! [**HTTP2/TLS**](https://static-web-server.net/features/http2-tls/) |
 //! `http2` | Activates the HTTP2 and TLS feature.
 //! [**Compression**](https://static-web-server.net/features/compression/) |
@@ -94,6 +94,8 @@
 //! `fallback-page` | Activates the Fallback Page feature.
 //! **Metrics** |
 //! `metrics` | Activates the Prometheus metrics endpoint (`/metrics`). Enabled by default but requires the `--metrics` flag at runtime. Tokio runtime metrics are additionally available via the `experimental` feature.
+//! **In-Memory Cache** |
+//! `mem-cache` | Activates the in-memory file cache with LFU admission and LRU eviction policies. Enabled by default and configured via TOML `[advanced.memory-cache]`.
 //!
 
 #![deny(missing_docs)]
@@ -159,8 +161,9 @@ pub mod https_redirect;
 pub(crate) mod log_addr;
 pub mod maintenance_mode;
 pub(crate) mod markdown;
-#[cfg(feature = "experimental")]
-pub(crate) mod mem_cache;
+#[cfg(feature = "mem-cache")]
+#[cfg_attr(docsrs, doc(cfg(feature = "mem-cache")))]
+pub mod mem_cache;
 #[cfg(feature = "metrics")]
 pub(crate) mod metrics;
 pub mod redirects;

--- a/src/mem_cache/cache.rs
+++ b/src/mem_cache/cache.rs
@@ -21,7 +21,6 @@ use std::io::{Read, Seek, SeekFrom};
 use std::path::Path;
 use std::sync::{Arc, OnceLock};
 use std::time::Duration;
-use tokio::sync::{Semaphore, SemaphorePermit};
 
 use crate::Result;
 use crate::body::Body;
@@ -33,9 +32,6 @@ use crate::response::{BadRangeError, bytes_range};
 /// Global cache that stores all files in memory.
 /// It provides expiration policies like Time to live (TTL) and Time to idle (TTI) support.
 pub(crate) static CACHE_STORE: OnceLock<Cache<CompactString, Arc<MemFile>>> = OnceLock::new();
-
-/// A single cache permit to allow reading a file once.
-static CACHE_PERMIT: Semaphore = Semaphore::const_new(1);
 
 /// It defines the in-memory files cache options.
 pub struct MemCacheOpts {
@@ -115,64 +111,26 @@ pub fn init(handler_opts: &mut RequestHandlerOpts) -> Result {
     Ok(())
 }
 
-/// Result of a cache lookup via `get_or_acquire`.
-pub(crate) enum CacheResult<'a> {
-    /// Cache hit — return the response directly.
-    Hit(Result<Response<Body>, StatusCode>),
-    /// Cache miss — caller should read the file. The semaphore permit is held
-    /// so that concurrent misses are serialized (single-flight). Drop the permit
-    /// after inserting into the cache store.
-    Miss(SemaphorePermit<'a>),
-    /// An error occurred acquiring the semaphore.
-    Error(StatusCode),
-}
-
-/// Try to get the file in a form of a response from the cache store by a path or
-/// acquires a permit to ensure to hold until the file is read first (once).
+/// Try to get a cached response for the given file path.
 ///
-/// If the file is not found in the cache store then
-/// a cache permit is acquired internally (one at a time)
-/// to allow the caller to read the file first.
-/// Once the file is read on caller's side then the permit is dropped.
-pub(crate) async fn get_or_acquire(
+/// Returns `Some(result)` on a cache hit (the result itself may be an error
+/// status, e.g. for a malformed `Range` header) or `None` when the cache is
+/// disabled, the path is non-UTF-8, or there is no entry yet (cache miss).
+///
+/// The caller is responsible for reading the file from disk on a miss and
+/// inserting it into the cache via the streaming pipeline. There is no
+/// single-flight serialization: mini-moka's `Cache` is concurrency-safe and
+/// duplicate inserts under contention are benign and rare in practice.
+pub(crate) fn lookup(
     file_path: &Path,
     headers_opt: &HeaderMap,
-) -> Option<CacheResult<'static>> {
-    let file_path_str = file_path.to_str().or(None)?;
-
+) -> Option<Result<Response<Body>, StatusCode>> {
+    let file_path_str = file_path.to_str()?;
     let store = CACHE_STORE.get()?;
-    match store.get::<CompactString>(&file_path_str.into()) {
-        Some(mem_file) => {
-            tracing::debug!(
-                "file `{}` found in the in-memory cache store, returning it directly",
-                file_path_str
-            );
-            Some(CacheResult::Hit(mem_file.response_body(headers_opt)))
-        }
-        _ => {
-            tracing::debug!(
-                "file `{}` was not found in the in-memory cache store, continuing",
-                file_path_str
-            );
-            // If a file is not found in the store then continue
-            // with the normal flow and wait on first file read.
-            // Hold the permit so concurrent misses are serialized.
-            match CACHE_PERMIT.acquire().await {
-                Ok(permit) => {
-                    // Re-check after acquiring — another request may have populated
-                    // the cache while we were waiting for the permit.
-                    if let Some(mem_file) = store.get::<CompactString>(&file_path_str.into()) {
-                        return Some(CacheResult::Hit(mem_file.response_body(headers_opt)));
-                    }
-                    Some(CacheResult::Miss(permit))
-                }
-                Err(err) => {
-                    tracing::error!("error trying to acquire permit on first read: {:?}", err);
-                    Some(CacheResult::Error(StatusCode::INTERNAL_SERVER_ERROR))
-                }
-            }
-        }
-    }
+    let key = CompactString::from(file_path_str);
+    let mem_file = store.get(&key)?;
+    tracing::debug!("file `{file_path_str}` served from the in-memory cache store");
+    Some(mem_file.response_body(headers_opt))
 }
 
 #[derive(Debug, Clone)]
@@ -405,5 +363,21 @@ mod tests {
 
         let opts = MemCacheOpts::new(max_file_size);
         assert_eq!(opts.max_file_size, MAX_FILE_SIZE * 1024);
+    }
+
+    #[test]
+    fn lookup_returns_none_when_store_uninitialized() {
+        // When the global `CACHE_STORE` is not initialized (because `init` was
+        // never called with a `[advanced.memory-cache]` section in TOML), the
+        // lookup must short-circuit to `None` so that the regular file pipeline
+        // serves the request without paying any cache overhead.
+        let headers = HeaderMap::new();
+        let path = std::path::Path::new("/nonexistent/path.txt");
+        // Note: this test relies on the cache not being initialized in unit
+        // tests context. If another test in this module ever initializes the
+        // global store, this assertion becomes a hit/miss check instead.
+        if CACHE_STORE.get().is_none() {
+            assert!(lookup(path, &headers).is_none());
+        }
     }
 }

--- a/src/mem_cache/cache.rs
+++ b/src/mem_cache/cache.rs
@@ -15,6 +15,7 @@ use compact_str::CompactString;
 use headers::{
     AcceptRanges, ContentLength, ContentRange, ContentType, HeaderMap, HeaderMapExt, LastModified,
 };
+use hyper::header::{HeaderName, HeaderValue};
 use hyper::{Response, StatusCode};
 use mini_moka::sync::Cache;
 use std::io::{Read, Seek, SeekFrom};
@@ -32,6 +33,11 @@ use crate::response::{BadRangeError, bytes_range};
 /// Global cache that stores all files in memory.
 /// It provides expiration policies like Time to live (TTL) and Time to idle (TTI) support.
 pub(crate) static CACHE_STORE: OnceLock<Cache<CompactString, Arc<MemFile>>> = OnceLock::new();
+
+/// Standard `X-Cache` header to indicate whether a response was served from cache.
+pub(crate) static X_CACHE: HeaderName = HeaderName::from_static("x-cache");
+/// Value for the `X-Cache` header when the response is a cache hit.
+pub(crate) static X_CACHE_HIT: HeaderValue = HeaderValue::from_static("HIT");
 
 /// It defines the in-memory files cache options.
 pub struct MemCacheOpts {
@@ -54,8 +60,8 @@ const MAX_CAPACITY: u64 = 100_000;
 const MAX_TTL: u64 = 86_400;
 /// Maximum allowed TTI in seconds (1 hour).
 const MAX_TTI: u64 = 3_600;
-/// Maximum allowed file size in KiB (256 MiB = 262144 KiB).
-const MAX_FILE_SIZE: u64 = 262_144;
+/// Maximum allowed file size in KiB (32 MiB = 32768 KiB).
+const MAX_FILE_SIZE: u64 = 32_768;
 
 impl MemCacheOpts {
     /// Creates a new instance of `MemCacheOpts`.
@@ -130,7 +136,13 @@ pub(crate) fn lookup(
     let key = CompactString::from(file_path_str);
     let mem_file = store.get(&key)?;
     tracing::debug!("file `{file_path_str}` served from the in-memory cache store");
-    Some(mem_file.response_body(headers_opt))
+    // Tag the response with `X-Cache: HIT` so clients and tooling can
+    // identify that it was served from the in-memory cache.
+    Some(mem_file.response_body(headers_opt).map(|mut resp| {
+        resp.headers_mut()
+            .insert(X_CACHE.clone(), X_CACHE_HIT.clone());
+        resp
+    }))
 }
 
 #[derive(Debug, Clone)]
@@ -292,7 +304,7 @@ mod tests {
         const {
             assert!(MAX_TTI >= DEFAULT_TTI);
         }
-        // File size capped at 256 MiB (in KiB)
+        // File size capped at 32 MiB (in KiB)
         const {
             assert!(MAX_FILE_SIZE >= DEFAULT_MAX_FILE_SIZE);
         }
@@ -379,5 +391,11 @@ mod tests {
         if CACHE_STORE.get().is_none() {
             assert!(lookup(path, &headers).is_none());
         }
+    }
+
+    #[test]
+    fn x_cache_header_constants_are_valid() {
+        assert_eq!(X_CACHE.as_str(), "x-cache");
+        assert_eq!(X_CACHE_HIT.to_str().unwrap(), "HIT");
     }
 }

--- a/src/mem_cache/cache.rs
+++ b/src/mem_cache/cache.rs
@@ -43,43 +43,61 @@ pub struct MemCacheOpts {
     pub max_file_size: u64,
 }
 
+/// Default capacity (number of entries).
+pub const DEFAULT_CAPACITY: u64 = 100;
+/// Default time-to-live in seconds (30 minutes).
+pub const DEFAULT_TTL: u64 = 1800;
+/// Default time-to-idle in seconds (5 minutes).
+pub const DEFAULT_TTI: u64 = 300;
+/// Default maximum file size in KiB (8 MiB = 8192 KiB).
+pub const DEFAULT_MAX_FILE_SIZE: u64 = 8192;
+
+/// Maximum allowed capacity (entries).
+const MAX_CAPACITY: u64 = 100_000;
+/// Maximum allowed TTL in seconds (24 hours).
+const MAX_TTL: u64 = 86_400;
+/// Maximum allowed TTI in seconds (1 hour).
+const MAX_TTI: u64 = 3_600;
+/// Maximum allowed file size in KiB (256 MiB = 262144 KiB).
+const MAX_FILE_SIZE: u64 = 262_144;
+
 impl MemCacheOpts {
     /// Creates a new instance of `MemCacheOpts`.
+    /// `max_file_size` is in KiB and gets converted to bytes internally.
     #[inline]
     pub fn new(max_file_size: u64) -> Self {
         Self {
-            max_file_size: 1024 * 1024 * max_file_size,
+            max_file_size: max_file_size * 1024,
         }
     }
 }
 
-/// Make sure to initialize the in-memory cache store.
-pub(crate) fn init(handler_opts: &mut RequestHandlerOpts) -> Result {
+/// Initialize the in-memory cache store from handler options.
+///
+/// If `[advanced.memory-cache]` is present in the configuration, a cache store
+/// is created with the specified (or default) parameters. Values exceeding
+/// their allowed maximums are clamped silently.
+pub fn init(handler_opts: &mut RequestHandlerOpts) -> Result {
     if let Some(advanced_opts) = handler_opts.advanced_opts.as_ref()
         && let Some(opts) = advanced_opts.memory_cache.as_ref()
     {
-        // TODO: define maximum values
-
-        // Default 256 entries
-        let capacity = opts.capacity.unwrap_or(256);
-        // Default 1h
-        let ttl = opts.ttl.unwrap_or(3600);
-        // Default 5min
-        let tti = opts.tti.unwrap_or(300);
-        // Default 8mb
-        let max_file_size = opts.max_file_size.unwrap_or(8192);
+        let capacity = opts.capacity.unwrap_or(DEFAULT_CAPACITY).min(MAX_CAPACITY);
+        let ttl = opts.ttl.unwrap_or(DEFAULT_TTL).min(MAX_TTL);
+        let tti = opts.tti.unwrap_or(DEFAULT_TTI).min(MAX_TTI);
+        let max_file_size = opts
+            .max_file_size
+            .unwrap_or(DEFAULT_MAX_FILE_SIZE)
+            .min(MAX_FILE_SIZE);
 
         tracing::info!(
-            "in-memory cache (experimental): enabled=true, capacity={capacity}, ttl={ttl}, tti={tti}, max_file_size={max_file_size}"
+            "in-memory cache: enabled=true, capacity={capacity}, ttl={ttl}s, tti={tti}s, max_file_size={max_file_size}KiB"
         );
 
         let mem_opts = MemCacheOpts::new(max_file_size);
 
         let cache = Cache::builder()
             .max_capacity(capacity)
-            // Time to live (TTL): 30 minutes
             .time_to_live(Duration::from_secs(ttl))
-            // Time to idle (TTI):  5 minutes
             .time_to_idle(Duration::from_secs(tti))
             .build();
 
@@ -92,7 +110,7 @@ pub(crate) fn init(handler_opts: &mut RequestHandlerOpts) -> Result {
         return Ok(());
     }
 
-    tracing::info!("in-memory cache (experimental): enabled=false");
+    tracing::info!("in-memory cache: enabled=false");
 
     Ok(())
 }
@@ -122,7 +140,7 @@ pub(crate) async fn get_or_acquire(
 ) -> Option<CacheResult<'static>> {
     let file_path_str = file_path.to_str().or(None)?;
 
-    let store = CACHE_STORE.get().unwrap();
+    let store = CACHE_STORE.get()?;
     match store.get::<CompactString>(&file_path_str.into()) {
         Some(mem_file) => {
             tracing::debug!(
@@ -274,5 +292,118 @@ impl MemFile {
                     })
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mem_cache_opts_converts_kib_to_bytes() {
+        let opts = MemCacheOpts::new(8192);
+        // 8192 KiB = 8 MiB = 8_388_608 bytes
+        assert_eq!(opts.max_file_size, 8192 * 1024);
+    }
+
+    #[test]
+    fn mem_cache_opts_zero_size() {
+        let opts = MemCacheOpts::new(0);
+        assert_eq!(opts.max_file_size, 0);
+    }
+
+    #[test]
+    fn default_constants_are_sane() {
+        assert_eq!(DEFAULT_CAPACITY, 100);
+        assert_eq!(DEFAULT_TTL, 1800);
+        assert_eq!(DEFAULT_TTI, 300);
+        assert_eq!(DEFAULT_MAX_FILE_SIZE, 8192);
+    }
+
+    #[test]
+    fn max_constants_enforce_upper_bounds() {
+        // Capacity capped at 100k
+        const {
+            assert!(MAX_CAPACITY >= DEFAULT_CAPACITY);
+        }
+        // TTL capped at 24h
+        const {
+            assert!(MAX_TTL >= DEFAULT_TTL);
+        }
+        // TTI capped at 1h
+        const {
+            assert!(MAX_TTI >= DEFAULT_TTI);
+        }
+        // File size capped at 256 MiB (in KiB)
+        const {
+            assert!(MAX_FILE_SIZE >= DEFAULT_MAX_FILE_SIZE);
+        }
+    }
+
+    #[test]
+    fn init_returns_ok_without_advanced_opts() {
+        let mut handler_opts = crate::handler::RequestHandlerOpts::default();
+        let result = init(&mut handler_opts);
+        assert!(result.is_ok());
+        assert!(handler_opts.memory_cache.is_none());
+    }
+
+    #[test]
+    fn init_returns_ok_without_memory_cache_section() {
+        let mut handler_opts = RequestHandlerOpts {
+            advanced_opts: Some(crate::settings::Advanced {
+                headers: None,
+                rewrites: None,
+                redirects: None,
+                virtual_hosts: None,
+                memory_cache: None,
+            }),
+            ..Default::default()
+        };
+        let result = init(&mut handler_opts);
+        assert!(result.is_ok());
+        assert!(handler_opts.memory_cache.is_none());
+    }
+
+    #[test]
+    fn init_with_defaults_creates_cache() {
+        let mut handler_opts = RequestHandlerOpts {
+            advanced_opts: Some(crate::settings::Advanced {
+                headers: None,
+                rewrites: None,
+                redirects: None,
+                virtual_hosts: None,
+                memory_cache: Some(crate::settings::file::MemoryCache {
+                    capacity: None,
+                    ttl: None,
+                    tti: None,
+                    max_file_size: None,
+                }),
+            }),
+            ..Default::default()
+        };
+        let result = init(&mut handler_opts);
+        assert!(result.is_ok());
+        assert!(handler_opts.memory_cache.is_some());
+        let opts = handler_opts.memory_cache.unwrap();
+        assert_eq!(opts.max_file_size, DEFAULT_MAX_FILE_SIZE * 1024);
+    }
+
+    #[test]
+    fn init_clamps_values_to_max() {
+        // We can't call init() twice due to OnceLock, so test the clamping
+        // logic directly via the min() expressions.
+        let capacity = 999_999u64.min(MAX_CAPACITY);
+        let ttl = 999_999u64.min(MAX_TTL);
+        let tti = 999_999u64.min(MAX_TTI);
+        let max_file_size = 999_999u64.min(MAX_FILE_SIZE);
+
+        assert_eq!(capacity, MAX_CAPACITY);
+        assert_eq!(ttl, MAX_TTL);
+        assert_eq!(tti, MAX_TTI);
+        assert_eq!(max_file_size, MAX_FILE_SIZE);
+
+        let opts = MemCacheOpts::new(max_file_size);
+        assert_eq!(opts.max_file_size, MAX_FILE_SIZE * 1024);
     }
 }

--- a/src/mem_cache/mod.rs
+++ b/src/mem_cache/mod.rs
@@ -3,8 +3,11 @@
 // See https://static-web-server.net/ for more information
 // Copyright (C) 2019-present Jose Quintana <joseluisq.net>
 
-//! A module that provides several In-Memory cache facilities.
+//! In-memory file cache with LFU admission and LRU eviction.
 //!
+//! Provides file-level caching with configurable capacity, TTL, and TTI.
+//! Enabled via the `mem-cache` Cargo feature and configured through the
+//! `[advanced.memory-cache]` TOML section.
 
-pub(crate) mod cache;
+pub mod cache;
 pub(crate) mod stream;

--- a/src/mem_cache/stream.rs
+++ b/src/mem_cache/stream.rs
@@ -68,10 +68,9 @@ impl<T: Read + Unpin> Stream for MemCacheFileStream<T> {
                             file_path
                         );
 
-                        CACHE_STORE
-                            .get()
-                            .unwrap()
-                            .insert(file_path.into(), mem_file);
+                        if let Some(store) = CACHE_STORE.get() {
+                            store.insert(file_path.into(), mem_file);
+                        }
                     }
                 }
 

--- a/src/mem_cache/stream.rs
+++ b/src/mem_cache/stream.rs
@@ -7,27 +7,41 @@ use std::task::{Context, Poll};
 
 use crate::mem_cache::cache::{CACHE_STORE, MemFile, MemFileTempOpts};
 
+/// A streaming file reader that, on successful completion, inserts the
+/// fully-read bytes into the global in-memory cache store.
+///
+/// Only use this stream for **full-file** responses (no `Range` header).
+/// Range requests must use the plain [`crate::fs::stream::FileStream`] to
+/// avoid wasted allocations and to keep partial content out of the cache.
 #[derive(Debug)]
 pub(crate) struct MemCacheFileStream<T> {
-    pub(crate) reader: T,
-    pub(crate) buf_size: usize,
-    pub(crate) mem_opts: Option<MemFileTempOpts>,
-    pub(crate) mem_buf: Option<BytesMut>,
-    pub(crate) buf: BytesMut,
+    reader: T,
+    buf_size: usize,
+    /// Expected total byte length of the file. The cache is populated only
+    /// when the accumulated buffer length matches this value, which guards
+    /// against truncated reads (e.g. the file being modified mid-stream).
+    file_size: usize,
+    /// Metadata to attach to the cache entry. Taken on completion.
+    mem_opts: Option<MemFileTempOpts>,
+    /// Accumulator for the full file body. Taken on completion.
+    mem_buf: Option<BytesMut>,
+    /// Scratch read buffer reused on every poll.
+    buf: BytesMut,
 }
 
 impl<T> MemCacheFileStream<T> {
     pub(crate) fn new(
         reader: T,
         buf_size: usize,
-        mem_opts: Option<MemFileTempOpts>,
-        mem_buf: Option<BytesMut>,
+        mem_opts: MemFileTempOpts,
+        file_size: usize,
     ) -> Self {
         Self {
             reader,
             buf_size,
-            mem_opts,
-            mem_buf,
+            file_size,
+            mem_opts: Some(mem_opts),
+            mem_buf: Some(BytesMut::with_capacity(file_size)),
             buf: BytesMut::with_capacity(buf_size),
         }
     }
@@ -41,39 +55,33 @@ impl<T: Read + Unpin> Stream for MemCacheFileStream<T> {
         this.buf.resize(this.buf_size, 0);
 
         match this.reader.read(&mut this.buf[..]) {
-            Ok(0) => Poll::Ready(None),
-            Ok(n) => {
-                let buf = this.buf.split_to(n).freeze();
-
-                // Handle in-memory cache if enabled
-                if let (Some(mem_opts), Some(buf_data_mut)) =
-                    (this.mem_opts.as_ref(), this.mem_buf.as_mut())
+            Ok(0) => {
+                // Stream complete. Insert into the cache store only if we
+                // accumulated exactly `file_size` bytes; a smaller buffer
+                // indicates a truncated read (e.g. the file was modified or
+                // unlinked mid-stream) and must not be cached.
+                if let (Some(mem_opts), Some(mem_buf)) = (this.mem_opts.take(), this.mem_buf.take())
+                    && mem_buf.len() == this.file_size
                 {
-                    buf_data_mut.extend_from_slice(&buf);
-
-                    // If file size is reached then proceed cache it
-                    if buf_data_mut.len() == buf_data_mut.capacity() {
-                        let buf_data = this.mem_buf.take().unwrap().freeze();
-
-                        let mem_file = Arc::new(MemFile::new(
-                            buf_data,
-                            this.buf_size,
-                            mem_opts.content_type.to_owned(),
-                            mem_opts.last_modified,
-                        ));
-
-                        let file_path = mem_opts.file_path.as_str();
-                        tracing::debug!(
-                            "file `{}` is inserted to the in-memory cache store",
-                            file_path
-                        );
-
-                        if let Some(store) = CACHE_STORE.get() {
-                            store.insert(file_path.into(), mem_file);
-                        }
+                    let file_path = mem_opts.file_path.as_str();
+                    tracing::debug!("file `{file_path}` inserted into in-memory cache store");
+                    let mem_file = Arc::new(MemFile::new(
+                        mem_buf.freeze(),
+                        this.buf_size,
+                        mem_opts.content_type,
+                        mem_opts.last_modified,
+                    ));
+                    if let Some(store) = CACHE_STORE.get() {
+                        store.insert(file_path.into(), mem_file);
                     }
                 }
-
+                Poll::Ready(None)
+            }
+            Ok(n) => {
+                let buf = this.buf.split_to(n).freeze();
+                if let Some(mem_buf) = this.mem_buf.as_mut() {
+                    mem_buf.extend_from_slice(&buf);
+                }
                 Poll::Ready(Some(Ok(buf)))
             }
             Err(err) => Poll::Ready(Some(Err(err))),

--- a/src/response.rs
+++ b/src/response.rs
@@ -20,12 +20,9 @@ use crate::conditional_headers::{ConditionalBody, ConditionalHeaders};
 use crate::fs::stream::{FileStream, optimal_buf_size};
 
 #[cfg(feature = "mem-cache")]
-use {
-    crate::mem_cache::{
-        cache::{MemCacheOpts, MemFileTempOpts},
-        stream::MemCacheFileStream,
-    },
-    bytes::BytesMut,
+use crate::mem_cache::{
+    cache::{MemCacheOpts, MemFileTempOpts},
+    stream::MemCacheFileStream,
 };
 
 /// It converts a file object into a corresponding HTTP response or
@@ -67,38 +64,41 @@ pub(crate) fn response_body(
                     let mime = mime_guess::from_path(path).first_or_octet_stream();
                     let content_type = ContentType::from(mime);
 
-                    // Add the file to the in-memory cache only under these conditions:
-                    // - if the feature is enabled and
-                    // - if the file size does not exceed the maximum permitted and
-                    // - if the file is not found in the cache store
-                    // TODO: make this a feature
+                    // Select the response body. The in-memory cache pipeline
+                    // (`MemCacheFileStream`) is only used for **full-file**
+                    // responses (no `Range` header) that fit within the
+                    // configured size limit and when the path is valid UTF-8.
+                    // Range requests and all other cases use the plain
+                    // `FileStream` to avoid wasted allocations and to keep
+                    // partial content out of the cache.
                     #[cfg(feature = "mem-cache")]
-                    let body = match memory_cache {
-                        // Cache the file only if does not exceed the max size
-                        Some(mem_cache_opts) if len <= mem_cache_opts.max_file_size => {
-                            match path.to_str() {
-                                Some(path_str) => {
-                                    let content_type = content_type.clone();
-                                    let file_path = path_str.to_owned();
-
-                                    let mem_buf = Some(BytesMut::with_capacity(len as usize));
-                                    let mem_opts = Some(MemFileTempOpts::new(
-                                        file_path,
-                                        content_type,
-                                        modified,
-                                    ));
-                                    tracing::debug!(
-                                        "preparing `{}` to be inserted in-memory cache store",
-                                        path_str,
-                                    );
-                                    crate::body::stream(MemCacheFileStream::new(
-                                        reader, buf_size, mem_opts, mem_buf,
-                                    ))
-                                }
-                                _ => crate::body::stream(FileStream::new(reader, buf_size)),
+                    let body = {
+                        let is_full_response = sub_len == len;
+                        let mem_opts = match (is_full_response, memory_cache, path.to_str()) {
+                            (true, Some(opts), Some(path_str)) if len <= opts.max_file_size => {
+                                Some(MemFileTempOpts::new(
+                                    path_str.to_owned(),
+                                    content_type.clone(),
+                                    modified,
+                                ))
                             }
+                            _ => None,
+                        };
+                        match mem_opts {
+                            Some(mem_opts) => {
+                                tracing::debug!(
+                                    "preparing `{}` to be inserted in-memory cache store",
+                                    mem_opts.file_path.as_str(),
+                                );
+                                crate::body::stream(MemCacheFileStream::new(
+                                    reader,
+                                    buf_size,
+                                    mem_opts,
+                                    len as usize,
+                                ))
+                            }
+                            None => crate::body::stream(FileStream::new(reader, buf_size)),
                         }
-                        _ => crate::body::stream(FileStream::new(reader, buf_size)),
                     };
 
                     #[cfg(not(feature = "mem-cache"))]

--- a/src/response.rs
+++ b/src/response.rs
@@ -19,7 +19,7 @@ use crate::body::Body;
 use crate::conditional_headers::{ConditionalBody, ConditionalHeaders};
 use crate::fs::stream::{FileStream, optimal_buf_size};
 
-#[cfg(feature = "experimental")]
+#[cfg(feature = "mem-cache")]
 use {
     crate::mem_cache::{
         cache::{MemCacheOpts, MemFileTempOpts},
@@ -35,7 +35,7 @@ pub(crate) fn response_body(
     path: &PathBuf,
     meta: &Metadata,
     conditionals: ConditionalHeaders,
-    #[cfg(feature = "experimental")] memory_cache: Option<&MemCacheOpts>,
+    #[cfg(feature = "mem-cache")] memory_cache: Option<&MemCacheOpts>,
 ) -> Result<Response<Body>, StatusCode> {
     let mut len = meta.len();
     // If the file's modified time is the UNIX epoch, then it's likely not valid and should
@@ -72,7 +72,7 @@ pub(crate) fn response_body(
                     // - if the file size does not exceed the maximum permitted and
                     // - if the file is not found in the cache store
                     // TODO: make this a feature
-                    #[cfg(feature = "experimental")]
+                    #[cfg(feature = "mem-cache")]
                     let body = match memory_cache {
                         // Cache the file only if does not exceed the max size
                         Some(mem_cache_opts) if len <= mem_cache_opts.max_file_size => {
@@ -101,7 +101,7 @@ pub(crate) fn response_body(
                         _ => crate::body::stream(FileStream::new(reader, buf_size)),
                     };
 
-                    #[cfg(not(feature = "experimental"))]
+                    #[cfg(not(feature = "mem-cache"))]
                     let body = crate::body::stream(FileStream::new(reader, buf_size));
 
                     let mut resp = Response::new(body);

--- a/src/server/opts.rs
+++ b/src/server/opts.rs
@@ -28,7 +28,7 @@ use crate::metrics;
 #[cfg(feature = "basic-auth")]
 use crate::basic_auth;
 
-#[cfg(feature = "experimental")]
+#[cfg(feature = "mem-cache")]
 use crate::mem_cache;
 
 #[cfg(any(
@@ -198,8 +198,8 @@ pub(super) fn init(general: &General, advanced: Option<Advanced>) -> Result<Hand
     // Security headers
     security_headers::init(general.security_headers, &mut handler_opts);
 
-    // In-memory cache (experimental)
-    #[cfg(feature = "experimental")]
+    // In-memory cache
+    #[cfg(feature = "mem-cache")]
     mem_cache::cache::init(&mut handler_opts)?;
 
     Ok(HandlerOptsResult {

--- a/src/settings/file.rs
+++ b/src/settings/file.rs
@@ -164,10 +164,9 @@ pub struct VirtualHosts {
     pub root: Option<PathBuf>,
 }
 
-#[cfg(feature = "experimental")]
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "kebab-case")]
-/// Represents the in-memory file cache feature.
+/// Represents the in-memory file cache configuration.
 pub struct MemoryCache {
     /// Maximum capacity entries of the memory cache store.
     pub capacity: Option<u64>,
@@ -175,7 +174,7 @@ pub struct MemoryCache {
     pub ttl: Option<u64>,
     /// Time to idle in seconds of a cached file entry.
     pub tti: Option<u64>,
-    /// Maximum size in bytes for a file entry to be cached.
+    /// Maximum file size in KiB for a file entry to be cached.
     pub max_file_size: Option<u64>,
 }
 
@@ -191,8 +190,7 @@ pub struct Advanced {
     pub redirects: Option<Vec<Redirects>>,
     /// Name-based virtual hosting
     pub virtual_hosts: Option<Vec<VirtualHosts>>,
-    #[cfg(feature = "experimental")]
-    /// In-memory cache feature (experimental).
+    /// In-memory cache feature.
     pub memory_cache: Option<MemoryCache>,
 }
 
@@ -394,10 +392,6 @@ pub struct General {
 
     /// Custom maintenance mode HTML file.
     pub maintenance_mode_file: Option<PathBuf>,
-
-    #[cfg(feature = "experimental")]
-    /// In-memory files cache feature.
-    pub memory_cache: Option<bool>,
 
     #[cfg(windows)]
     /// windows service feature.

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -25,7 +25,6 @@ pub use cli::Commands;
 
 use cli::General;
 
-#[cfg(feature = "experimental")]
 use self::file::MemoryCache;
 
 use self::file::{RedirectsKind, Settings as FileSettings};
@@ -92,8 +91,7 @@ pub struct Advanced {
     pub redirects: Option<Vec<Redirects>>,
     /// Name-based virtual hosting
     pub virtual_hosts: Option<Vec<VirtualHosts>>,
-    #[cfg(feature = "experimental")]
-    /// In-memory cache feature (experimental).
+    /// In-memory cache configuration.
     pub memory_cache: Option<MemoryCache>,
 }
 
@@ -625,7 +623,6 @@ impl Settings {
                     rewrites: rewrites_entries,
                     redirects: redirects_entries,
                     virtual_hosts: vhosts_entries,
-                    #[cfg(feature = "experimental")]
                     memory_cache: advanced.memory_cache,
                 });
             }

--- a/src/static_files/mod.rs
+++ b/src/static_files/mod.rs
@@ -52,14 +52,13 @@ pub async fn handle(opts: &HandleOpts<'_>) -> Result<StaticFileResponse, StatusC
 
     let mut file_path = sanitize_path(opts.base_path, opts.uri_path)?;
 
-    // In-memory file cache lookup. A hit short-circuits the
-    // pipeline; a miss returns a permit that lives until the file stream
-    // finishes populating the cache.
+    // In-memory file cache lookup. A hit short-circuits the pipeline.
+    // On miss, the file is read from disk and the streaming pipeline
+    // populates the cache opportunistically (see `mem_cache::stream`).
     #[cfg(feature = "mem-cache")]
-    let _cache_permit = match try_memory_cache(opts, &mut file_path).await? {
-        MemCacheOutcome::Hit(resp) => return Ok(resp),
-        MemCacheOutcome::Miss(permit) => permit,
-    };
+    if let Some(resp) = try_memory_cache(opts, &mut file_path) {
+        return Ok(resp);
+    }
 
     let FileMetadata {
         file_path,
@@ -97,30 +96,23 @@ pub async fn handle(opts: &HandleOpts<'_>) -> Result<StaticFileResponse, StatusC
     Ok(StaticFileResponse::new(resp, resp_file_path))
 }
 
-/// Outcome of the in-memory cache lookup.
-#[cfg(feature = "mem-cache")]
-enum MemCacheOutcome {
-    /// The response is fully resolved from cache.
-    Hit(StaticFileResponse),
-    /// Cache miss. The held permit must be kept alive until the
-    /// downstream file stream finishes inserting the file into the cache.
-    Miss(Option<tokio::sync::SemaphorePermit<'static>>),
-}
-
 /// Tries to satisfy the request from the in-memory cache.
+///
+/// Returns `Some(response)` on a cache hit, `None` otherwise (cache disabled
+/// in the runtime config, no entry yet, or a non-UTF-8 path).
 ///
 /// When a memory cache is configured and the request targets a directory
 /// with trailing-slash redirect on, the cache key is the implicit
 /// `<dir>/index.html`. The function may push that segment onto
 /// `file_path` before performing the lookup.
 #[cfg(feature = "mem-cache")]
-async fn try_memory_cache(
+fn try_memory_cache(
     opts: &HandleOpts<'_>,
     file_path: &mut std::path::PathBuf,
-) -> Result<MemCacheOutcome, StatusCode> {
-    if opts.memory_cache.is_none() {
-        return Ok(MemCacheOutcome::Miss(None));
-    }
+) -> Option<StaticFileResponse> {
+    // Runtime gate: if `[advanced.memory-cache]` is not configured in TOML,
+    // `opts.memory_cache` is `None` and we skip the lookup entirely.
+    opts.memory_cache.as_ref()?;
 
     // NOTE: only the default auto-index is supported for directory
     // requests inside the memory-cache context.
@@ -128,16 +120,11 @@ async fn try_memory_cache(
         file_path.push("index.html");
     }
 
-    let Some(result) = cache::get_or_acquire(file_path.as_path(), opts.headers).await else {
-        return Ok(MemCacheOutcome::Miss(None));
-    };
-
+    let result = cache::lookup(file_path.as_path(), opts.headers)?;
     match result {
-        cache::CacheResult::Hit(result) => Ok(MemCacheOutcome::Hit(StaticFileResponse::new(
-            result?,
-            file_path.clone(),
-        ))),
-        cache::CacheResult::Error(status) => Err(status),
-        cache::CacheResult::Miss(permit) => Ok(MemCacheOutcome::Miss(Some(permit))),
+        Ok(resp) => Some(StaticFileResponse::new(resp, file_path.clone())),
+        // Hit, but the cached entry returned an error status (e.g. malformed Range).
+        // Fall through to the regular pipeline so the error path is consistent.
+        Err(_) => None,
     }
 }

--- a/src/static_files/mod.rs
+++ b/src/static_files/mod.rs
@@ -10,7 +10,7 @@
 //!
 //! 1. **Method check** — `GET`, `HEAD` and `OPTIONS` only.
 //! 2. **Path sanitization** — strip traversal components from the URI path.
-//! 3. **In-memory cache lookup** — short-circuit hot files (experimental).
+//! 3. **In-memory cache lookup** — short-circuit hot files.
 //! 4. **File resolution** — directory → index, `.html` fallback,
 //!    pre-compressed variant detection (see [`resolve`]).
 //! 5. **Security checks** — containment, symlink and hidden-file policy
@@ -40,7 +40,7 @@ use crate::exts::http::MethodExt;
 use crate::fs::meta::FileMetadata;
 use crate::fs::path::sanitize_path;
 
-#[cfg(feature = "experimental")]
+#[cfg(feature = "mem-cache")]
 use crate::mem_cache::cache;
 
 /// The server entry point to handle incoming requests which map to specific files
@@ -52,10 +52,10 @@ pub async fn handle(opts: &HandleOpts<'_>) -> Result<StaticFileResponse, StatusC
 
     let mut file_path = sanitize_path(opts.base_path, opts.uri_path)?;
 
-    // In-memory file cache lookup (experimental). A hit short-circuits the
+    // In-memory file cache lookup. A hit short-circuits the
     // pipeline; a miss returns a permit that lives until the file stream
     // finishes populating the cache.
-    #[cfg(feature = "experimental")]
+    #[cfg(feature = "mem-cache")]
     let _cache_permit = match try_memory_cache(opts, &mut file_path).await? {
         MemCacheOutcome::Hit(resp) => return Ok(resp),
         MemCacheOutcome::Miss(permit) => permit,
@@ -97,8 +97,8 @@ pub async fn handle(opts: &HandleOpts<'_>) -> Result<StaticFileResponse, StatusC
     Ok(StaticFileResponse::new(resp, resp_file_path))
 }
 
-/// Outcome of the experimental in-memory cache lookup.
-#[cfg(feature = "experimental")]
+/// Outcome of the in-memory cache lookup.
+#[cfg(feature = "mem-cache")]
 enum MemCacheOutcome {
     /// The response is fully resolved from cache.
     Hit(StaticFileResponse),
@@ -113,7 +113,7 @@ enum MemCacheOutcome {
 /// with trailing-slash redirect on, the cache key is the implicit
 /// `<dir>/index.html`. The function may push that segment onto
 /// `file_path` before performing the lookup.
-#[cfg(feature = "experimental")]
+#[cfg(feature = "mem-cache")]
 async fn try_memory_cache(
     opts: &HandleOpts<'_>,
     file_path: &mut std::path::PathBuf,

--- a/src/static_files/opts.rs
+++ b/src/static_files/opts.rs
@@ -11,7 +11,7 @@ use std::path::PathBuf;
 
 use crate::body::Body;
 
-#[cfg(feature = "experimental")]
+#[cfg(feature = "mem-cache")]
 use crate::mem_cache::cache::MemCacheOpts;
 
 #[cfg(feature = "directory-listing")]
@@ -27,8 +27,8 @@ pub(super) const DEFAULT_INDEX_FILES: &[&str; 1] = &["index.html"];
 pub struct HandleOpts<'a> {
     /// Request method.
     pub method: &'a Method,
-    /// In-memory files cache feature (experimental).
-    #[cfg(feature = "experimental")]
+    /// In-memory files cache feature.
+    #[cfg(feature = "mem-cache")]
     pub memory_cache: Option<&'a MemCacheOpts>,
     /// Request headers.
     pub headers: &'a HeaderMap<HeaderValue>,

--- a/src/static_files/reply.rs
+++ b/src/static_files/reply.rs
@@ -113,12 +113,12 @@ fn file_reply(
 
     match File::open(open_path) {
         Ok(file) => {
-            #[cfg(feature = "experimental")]
+            #[cfg(feature = "mem-cache")]
             {
                 response_body(file, path, meta, conditionals, opts.memory_cache)
             }
 
-            #[cfg(not(feature = "experimental"))]
+            #[cfg(not(feature = "mem-cache"))]
             {
                 let _ = opts;
                 response_body(file, path, meta, conditionals)

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -106,7 +106,7 @@ pub mod fixtures {
             maintenance_mode: general.maintenance_mode,
             maintenance_mode_status: general.maintenance_mode_status,
             maintenance_mode_file: general.maintenance_mode_file,
-            #[cfg(feature = "experimental")]
+            #[cfg(feature = "mem-cache")]
             memory_cache: None,
             advanced_opts: advanced,
         }

--- a/tests/dir_listing.rs
+++ b/tests/dir_listing.rs
@@ -47,7 +47,7 @@ mod tests {
                 base_path: &root_dir("tests/fixtures/public"),
                 uri_path: "/symlink",
                 uri_query: None,
-                #[cfg(feature = "experimental")]
+                #[cfg(feature = "mem-cache")]
                 memory_cache: None,
                 dir_listing: true,
                 dir_listing_order: 6,
@@ -84,7 +84,7 @@ mod tests {
                 base_path: &root_dir("docs/"),
                 uri_path: "/content/",
                 uri_query: None,
-                #[cfg(feature = "experimental")]
+                #[cfg(feature = "mem-cache")]
                 memory_cache: None,
                 dir_listing: true,
                 dir_listing_order: 6,
@@ -134,7 +134,7 @@ mod tests {
                 base_path: &root_dir("docs/"),
                 uri_path: "/content",
                 uri_query: None,
-                #[cfg(feature = "experimental")]
+                #[cfg(feature = "mem-cache")]
                 memory_cache: None,
                 dir_listing: true,
                 dir_listing_order: 6,
@@ -184,7 +184,7 @@ mod tests {
                 base_path: &root_dir("docs/"),
                 uri_path: "/README.md",
                 uri_query: None,
-                #[cfg(feature = "experimental")]
+                #[cfg(feature = "mem-cache")]
                 memory_cache: None,
                 dir_listing: true,
                 dir_listing_order: 6,
@@ -221,7 +221,7 @@ mod tests {
                 base_path: &root_dir("tests/fixtures/public/"),
                 uri_path: "/",
                 uri_query: None,
-                #[cfg(feature = "experimental")]
+                #[cfg(feature = "mem-cache")]
                 memory_cache: None,
                 dir_listing: true,
                 dir_listing_order: 6,
@@ -282,7 +282,7 @@ mod tests {
                 base_path: &root_dir("tests/fixtures/public/"),
                 uri_path: "/",
                 uri_query: None,
-                #[cfg(feature = "experimental")]
+                #[cfg(feature = "mem-cache")]
                 memory_cache: None,
                 dir_listing: true,
                 dir_listing_order: 1,
@@ -361,7 +361,7 @@ mod tests {
                 base_path: &root_dir(&empty_dir),
                 uri_path: "/",
                 uri_query: None,
-                #[cfg(feature = "experimental")]
+                #[cfg(feature = "mem-cache")]
                 memory_cache: None,
                 dir_listing: true,
                 dir_listing_order: 1,
@@ -413,7 +413,7 @@ mod tests {
                 base_path: &root_dir("tests/fixtures/public"),
                 uri_path: "/",
                 uri_query: None,
-                #[cfg(feature = "experimental")]
+                #[cfg(feature = "mem-cache")]
                 memory_cache: None,
                 dir_listing: true,
                 dir_listing_order: 1,
@@ -465,7 +465,7 @@ mod tests {
                 base_path: &root_dir("tests/fixtures/public"),
                 uri_path: "/",
                 uri_query: None,
-                #[cfg(feature = "experimental")]
+                #[cfg(feature = "mem-cache")]
                 memory_cache: None,
                 dir_listing: true,
                 dir_listing_order: 1,
@@ -516,7 +516,7 @@ mod tests {
                 base_path: &root_dir("tests/fixtures/public"),
                 uri_path: "/",
                 uri_query: None,
-                #[cfg(feature = "experimental")]
+                #[cfg(feature = "mem-cache")]
                 memory_cache: None,
                 dir_listing: true,
                 dir_listing_order: 1,

--- a/tests/dir_listing_download.rs
+++ b/tests/dir_listing_download.rs
@@ -131,7 +131,7 @@ mod tests {
                 base_path: &base_path,
                 uri_path: "/",
                 uri_query: Some(DOWNLOAD_PARAM_KEY),
-                #[cfg(feature = "experimental")]
+                #[cfg(feature = "mem-cache")]
                 memory_cache: None,
                 dir_listing: true,
                 dir_listing_order: 1,
@@ -206,7 +206,7 @@ mod tests {
                 base_path: &base_path,
                 uri_path: "/",
                 uri_query: Some(DOWNLOAD_PARAM_KEY),
-                #[cfg(feature = "experimental")]
+                #[cfg(feature = "mem-cache")]
                 memory_cache: None,
                 dir_listing: true,
                 dir_listing_order: 1,
@@ -270,7 +270,7 @@ mod tests {
                 base_path: &base_path,
                 uri_path: "/",
                 uri_query: Some(DOWNLOAD_PARAM_KEY),
-                #[cfg(feature = "experimental")]
+                #[cfg(feature = "mem-cache")]
                 memory_cache: None,
                 dir_listing: true,
                 dir_listing_order: 1,
@@ -344,7 +344,7 @@ mod tests {
                 base_path: &root_dir("tests/fixtures/public"),
                 uri_path: "/",
                 uri_query: Some(DOWNLOAD_PARAM_KEY),
-                #[cfg(feature = "experimental")]
+                #[cfg(feature = "mem-cache")]
                 memory_cache: None,
                 dir_listing: true,
                 dir_listing_order: 1,

--- a/tests/mem_cache.rs
+++ b/tests/mem_cache.rs
@@ -304,13 +304,36 @@ mod tests {
     async fn x_cache_hit_header_present_on_cache_hit() {
         let mem_opts = MemCacheOpts::new(DEFAULT_MAX_FILE_SIZE);
 
-        // First request: populates the cache (miss, no X-Cache header expected).
-        let opts1 = handle_opts(Some(&mem_opts));
-        let result1 = static_files::handle(&opts1).await;
-        assert!(result1.is_ok());
+        // Use a file that no other test in this binary touches, so we
+        // guarantee a true cache miss regardless of test execution order
+        // (the CACHE_STORE is a process-global OnceLock).
+        let make_opts = || HandleOpts {
+            method: &Method::GET,
+            headers: Box::leak(Box::new(HeaderMap::new())),
+            base_path: Box::leak(Box::new(root_dir())),
+            uri_path: "50x.html",
+            uri_query: None,
+            memory_cache: Some(Box::leak(Box::new(MemCacheOpts::new(
+                mem_opts.max_file_size / 1024,
+            )))),
+            #[cfg(feature = "directory-listing")]
+            dir_listing: false,
+            #[cfg(feature = "directory-listing")]
+            dir_listing_order: 6,
+            #[cfg(feature = "directory-listing")]
+            dir_listing_format: Box::leak(Box::new(DirListFmt::Html)),
+            #[cfg(feature = "directory-listing-download")]
+            dir_listing_download: &[],
+            redirect_trailing_slash: true,
+            compression_static: false,
+            ignore_hidden_files: false,
+            disable_symlinks: false,
+            index_files: &[],
+        };
 
-        // First request is a miss: served from disk, so no X-Cache header.
-        let resp1 = result1.unwrap().resp;
+        // First request — cache miss (file not yet in store).
+        let result1 = static_files::handle(&make_opts()).await;
+        let resp1 = result1.expect("first request should succeed").resp;
         assert!(
             resp1.headers().get("x-cache").is_none(),
             "X-Cache should not be set on a cache miss (first request)"
@@ -319,11 +342,9 @@ mod tests {
         // Consume the body so the streaming pipeline finishes and populates the cache.
         let _body1 = resp1.into_body().collect().await.unwrap().to_bytes();
 
-        // Second request: should be served from cache (hit).
-        let opts2 = handle_opts(Some(&mem_opts));
-        let result2 = static_files::handle(&opts2).await;
+        // Second request — should be served from cache (hit).
+        let result2 = static_files::handle(&make_opts()).await;
         assert!(result2.is_ok());
-
         let resp2 = result2.unwrap().resp;
         let x_cache = resp2
             .headers()

--- a/tests/mem_cache.rs
+++ b/tests/mem_cache.rs
@@ -131,20 +131,6 @@ mod tests {
         use static_web_server::handler::RequestHandlerOpts;
         use static_web_server::settings::Advanced;
 
-        // let mut handler_opts = RequestHandlerOpts::default();
-        // handler_opts.advanced_opts = Some(Advanced {
-        //     headers: None,
-        //     rewrites: None,
-        //     redirects: None,
-        //     virtual_hosts: None,
-        //     memory_cache: Some(MemoryCache {
-        //         capacity: Some(10),
-        //         ttl: Some(60),
-        //         tti: Some(30),
-        //         max_file_size: Some(1024),
-        //     }),
-        // });
-
         let memory_cache = Some(MemoryCache {
             capacity: Some(10),
             ttl: Some(60),
@@ -269,13 +255,11 @@ mod tests {
         assert_eq!(body1, body2);
     }
 
-    // -------------------------------------------------------------------------
     // Runtime gating via TOML config file.
     //
     // The in-memory cache must only activate when `[advanced.memory-cache]` is
     // present in the configuration file. Otherwise the server must behave as
     // if the feature were not compiled in (no allocation, no global state).
-    // -------------------------------------------------------------------------
 
     #[test]
     fn toml_fixture_enables_memory_cache() {
@@ -307,6 +291,58 @@ mod tests {
         assert!(
             mc.is_none(),
             "memory_cache should be None when `[advanced.memory-cache]` is absent"
+        );
+    }
+
+    // X-Cache response header.
+    //
+    // Responses served from the in-memory cache must include `X-Cache: HIT`.
+    // Responses from disk (cache miss or cache disabled) must NOT include the
+    // header.
+
+    #[tokio::test]
+    async fn x_cache_hit_header_present_on_cache_hit() {
+        let mem_opts = MemCacheOpts::new(DEFAULT_MAX_FILE_SIZE);
+
+        // First request: populates the cache (miss, no X-Cache header expected).
+        let opts1 = handle_opts(Some(&mem_opts));
+        let result1 = static_files::handle(&opts1).await;
+        assert!(result1.is_ok());
+
+        // First request is a miss: served from disk, so no X-Cache header.
+        let resp1 = result1.unwrap().resp;
+        assert!(
+            resp1.headers().get("x-cache").is_none(),
+            "X-Cache should not be set on a cache miss (first request)"
+        );
+
+        // Consume the body so the streaming pipeline finishes and populates the cache.
+        let _body1 = resp1.into_body().collect().await.unwrap().to_bytes();
+
+        // Second request: should be served from cache (hit).
+        let opts2 = handle_opts(Some(&mem_opts));
+        let result2 = static_files::handle(&opts2).await;
+        assert!(result2.is_ok());
+
+        let resp2 = result2.unwrap().resp;
+        let x_cache = resp2
+            .headers()
+            .get("x-cache")
+            .expect("X-Cache header must be present on a cache hit");
+        assert_eq!(x_cache, "HIT");
+    }
+
+    #[tokio::test]
+    async fn x_cache_header_absent_when_cache_disabled() {
+        // With memory_cache = None, no X-Cache header should ever appear.
+        let opts = handle_opts(None);
+        let result = static_files::handle(&opts).await;
+        assert!(result.is_ok());
+
+        let resp = result.unwrap().resp;
+        assert!(
+            resp.headers().get("x-cache").is_none(),
+            "X-Cache should never appear when the in-memory cache is disabled"
         );
     }
 }

--- a/tests/mem_cache.rs
+++ b/tests/mem_cache.rs
@@ -268,4 +268,45 @@ mod tests {
 
         assert_eq!(body1, body2);
     }
+
+    // -------------------------------------------------------------------------
+    // Runtime gating via TOML config file.
+    //
+    // The in-memory cache must only activate when `[advanced.memory-cache]` is
+    // present in the configuration file. Otherwise the server must behave as
+    // if the feature were not compiled in (no allocation, no global state).
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn toml_fixture_enables_memory_cache() {
+        use static_web_server::settings::file::Settings;
+        use std::path::Path;
+
+        let config_path = Path::new("tests/toml/memory_cache.toml");
+        let settings = Settings::read(config_path).unwrap();
+        let advanced = settings.advanced.expect("`[advanced]` section missing");
+        let mc = advanced
+            .memory_cache
+            .expect("`[advanced.memory-cache]` section missing");
+
+        assert_eq!(mc.capacity, Some(50));
+        assert_eq!(mc.ttl, Some(600));
+        assert_eq!(mc.tti, Some(120));
+        assert_eq!(mc.max_file_size, Some(4));
+    }
+
+    #[test]
+    fn toml_fixture_without_memory_cache_section_disables_feature() {
+        use static_web_server::settings::file::Settings;
+        use std::path::Path;
+
+        let config_path = Path::new("tests/fixtures/toml/handler.toml");
+        let settings = Settings::read(config_path).unwrap();
+        // The `[advanced]` table may exist but `memory-cache` must be absent.
+        let mc = settings.advanced.and_then(|a| a.memory_cache);
+        assert!(
+            mc.is_none(),
+            "memory_cache should be None when `[advanced.memory-cache]` is absent"
+        );
+    }
 }

--- a/tests/mem_cache.rs
+++ b/tests/mem_cache.rs
@@ -1,0 +1,271 @@
+#![forbid(unsafe_code)]
+#![deny(warnings)]
+#![deny(rust_2018_idioms)]
+#![deny(dead_code)]
+
+#[cfg(all(test, feature = "mem-cache"))]
+mod tests {
+    use bytes::Bytes;
+    use headers::HeaderMap;
+    use http::{Method, StatusCode};
+    use http_body_util::BodyExt;
+    use std::path::PathBuf;
+
+    #[cfg(feature = "directory-listing")]
+    use static_web_server::directory_listing::DirListFmt;
+    use static_web_server::static_files::{self, HandleOpts};
+
+    use static_web_server::mem_cache::cache::{
+        self, DEFAULT_CAPACITY, DEFAULT_MAX_FILE_SIZE, DEFAULT_TTI, DEFAULT_TTL, MemCacheOpts,
+    };
+    use static_web_server::settings::file::MemoryCache;
+
+    fn root_dir() -> PathBuf {
+        PathBuf::from("tests/fixtures/public/")
+    }
+
+    fn handle_opts(memory_cache: Option<&MemCacheOpts>) -> HandleOpts<'static> {
+        // Leak references for test convenience (short-lived test processes).
+        let mc: Option<&'static MemCacheOpts> = memory_cache.map(|m| {
+            let boxed = Box::new(MemCacheOpts::new(m.max_file_size / 1024));
+            &*Box::leak(boxed)
+        });
+        HandleOpts {
+            method: &Method::GET,
+            headers: Box::leak(Box::new(HeaderMap::new())),
+            base_path: Box::leak(Box::new(root_dir())),
+            uri_path: "index.htm",
+            uri_query: None,
+            memory_cache: mc,
+            #[cfg(feature = "directory-listing")]
+            dir_listing: false,
+            #[cfg(feature = "directory-listing")]
+            dir_listing_order: 6,
+            #[cfg(feature = "directory-listing")]
+            dir_listing_format: Box::leak(Box::new(DirListFmt::Html)),
+            #[cfg(feature = "directory-listing-download")]
+            dir_listing_download: &[],
+            redirect_trailing_slash: true,
+            compression_static: false,
+            ignore_hidden_files: false,
+            disable_symlinks: false,
+            index_files: &["index.htm"],
+        }
+    }
+
+    #[test]
+    fn memory_cache_config_defaults() {
+        let cfg = MemoryCache {
+            capacity: None,
+            ttl: None,
+            tti: None,
+            max_file_size: None,
+        };
+        assert_eq!(cfg.capacity.unwrap_or(DEFAULT_CAPACITY), 100);
+        assert_eq!(cfg.ttl.unwrap_or(DEFAULT_TTL), 1800);
+        assert_eq!(cfg.tti.unwrap_or(DEFAULT_TTI), 300);
+        assert_eq!(cfg.max_file_size.unwrap_or(DEFAULT_MAX_FILE_SIZE), 8192);
+    }
+
+    #[test]
+    fn memory_cache_config_custom_values() {
+        let cfg = MemoryCache {
+            capacity: Some(50),
+            ttl: Some(600),
+            tti: Some(120),
+            max_file_size: Some(4096),
+        };
+        assert_eq!(cfg.capacity.unwrap(), 50);
+        assert_eq!(cfg.ttl.unwrap(), 600);
+        assert_eq!(cfg.tti.unwrap(), 120);
+        assert_eq!(cfg.max_file_size.unwrap(), 4096);
+    }
+
+    #[test]
+    fn memory_cache_config_deserializes_from_toml() {
+        let toml_str = r#"
+            capacity = 200
+            ttl = 900
+            tti = 60
+            max-file-size = 16384
+        "#;
+        let cfg: MemoryCache = toml::from_str(toml_str).unwrap();
+        assert_eq!(cfg.capacity, Some(200));
+        assert_eq!(cfg.ttl, Some(900));
+        assert_eq!(cfg.tti, Some(60));
+        assert_eq!(cfg.max_file_size, Some(16384));
+    }
+
+    #[test]
+    fn memory_cache_config_deserializes_empty_toml() {
+        let toml_str = "";
+        let cfg: MemoryCache = toml::from_str(toml_str).unwrap();
+        assert_eq!(cfg.capacity, None);
+        assert_eq!(cfg.ttl, None);
+        assert_eq!(cfg.tti, None);
+        assert_eq!(cfg.max_file_size, None);
+    }
+
+    #[test]
+    fn memory_cache_config_partial_toml() {
+        let toml_str = r#"
+            capacity = 50
+            max-file-size = 1024
+        "#;
+        let cfg: MemoryCache = toml::from_str(toml_str).unwrap();
+        assert_eq!(cfg.capacity, Some(50));
+        assert_eq!(cfg.ttl, None);
+        assert_eq!(cfg.tti, None);
+        assert_eq!(cfg.max_file_size, Some(1024));
+    }
+
+    #[test]
+    fn mem_cache_opts_file_size_conversion() {
+        // 8192 KiB = 8 MiB in bytes
+        let opts = MemCacheOpts::new(8192);
+        assert_eq!(opts.max_file_size, 8192 * 1024);
+    }
+
+    #[test]
+    fn cache_init_populates_store() {
+        use static_web_server::handler::RequestHandlerOpts;
+        use static_web_server::settings::Advanced;
+
+        // let mut handler_opts = RequestHandlerOpts::default();
+        // handler_opts.advanced_opts = Some(Advanced {
+        //     headers: None,
+        //     rewrites: None,
+        //     redirects: None,
+        //     virtual_hosts: None,
+        //     memory_cache: Some(MemoryCache {
+        //         capacity: Some(10),
+        //         ttl: Some(60),
+        //         tti: Some(30),
+        //         max_file_size: Some(1024),
+        //     }),
+        // });
+
+        let memory_cache = Some(MemoryCache {
+            capacity: Some(10),
+            ttl: Some(60),
+            tti: Some(30),
+            max_file_size: Some(1024),
+        });
+        let mut handler_opts = RequestHandlerOpts {
+            advanced_opts: Some(Advanced {
+                headers: None,
+                rewrites: None,
+                redirects: None,
+                virtual_hosts: None,
+                memory_cache,
+            }),
+            ..Default::default()
+        };
+
+        let result = cache::init(&mut handler_opts);
+        assert!(result.is_ok());
+        assert!(handler_opts.memory_cache.is_some());
+        let opts = handler_opts.memory_cache.as_ref().unwrap();
+        assert_eq!(opts.max_file_size, 1024 * 1024); // 1024 KiB in bytes
+    }
+
+    #[tokio::test]
+    async fn static_file_served_with_cache_enabled() {
+        let mem_opts = MemCacheOpts::new(DEFAULT_MAX_FILE_SIZE);
+        let opts = handle_opts(Some(&mem_opts));
+
+        let result = static_files::handle(&opts).await;
+        assert!(result.is_ok());
+
+        let resp = result.unwrap();
+        assert_eq!(resp.resp.status(), StatusCode::OK);
+
+        let body = resp.resp.into_body().collect().await.unwrap().to_bytes();
+        assert!(!body.is_empty());
+    }
+
+    #[tokio::test]
+    async fn static_file_served_without_cache() {
+        let opts = handle_opts(None);
+        let result = static_files::handle(&opts).await;
+        assert!(result.is_ok());
+
+        let resp = result.unwrap();
+        assert_eq!(resp.resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn cache_miss_then_hit_returns_same_content() {
+        let mem_opts = MemCacheOpts::new(DEFAULT_MAX_FILE_SIZE);
+
+        // First request: cache miss, populates cache
+        let opts1 = HandleOpts {
+            method: &Method::GET,
+            headers: &HeaderMap::new(),
+            base_path: &root_dir(),
+            uri_path: "index.htm",
+            uri_query: None,
+            memory_cache: Some(&mem_opts),
+            #[cfg(feature = "directory-listing")]
+            dir_listing: false,
+            #[cfg(feature = "directory-listing")]
+            dir_listing_order: 6,
+            #[cfg(feature = "directory-listing")]
+            dir_listing_format: &DirListFmt::Html,
+            #[cfg(feature = "directory-listing-download")]
+            dir_listing_download: &[],
+            redirect_trailing_slash: true,
+            compression_static: false,
+            ignore_hidden_files: false,
+            disable_symlinks: false,
+            index_files: &["index.htm"],
+        };
+
+        let result1 = static_files::handle(&opts1).await;
+        assert!(result1.is_ok());
+        let body1: Bytes = result1
+            .unwrap()
+            .resp
+            .into_body()
+            .collect()
+            .await
+            .unwrap()
+            .to_bytes();
+
+        // Second request: should be served from cache (or at least produce same content)
+        let opts2 = HandleOpts {
+            method: &Method::GET,
+            headers: &HeaderMap::new(),
+            base_path: &root_dir(),
+            uri_path: "index.htm",
+            uri_query: None,
+            memory_cache: Some(&mem_opts),
+            #[cfg(feature = "directory-listing")]
+            dir_listing: false,
+            #[cfg(feature = "directory-listing")]
+            dir_listing_order: 6,
+            #[cfg(feature = "directory-listing")]
+            dir_listing_format: &DirListFmt::Html,
+            #[cfg(feature = "directory-listing-download")]
+            dir_listing_download: &[],
+            redirect_trailing_slash: true,
+            compression_static: false,
+            ignore_hidden_files: false,
+            disable_symlinks: false,
+            index_files: &["index.htm"],
+        };
+
+        let result2 = static_files::handle(&opts2).await;
+        assert!(result2.is_ok());
+        let body2: Bytes = result2
+            .unwrap()
+            .resp
+            .into_body()
+            .collect()
+            .await
+            .unwrap()
+            .to_bytes();
+
+        assert_eq!(body1, body2);
+    }
+}

--- a/tests/static_files.rs
+++ b/tests/static_files.rs
@@ -62,7 +62,7 @@ mod tests {
             base_path: &root_dir(),
             uri_path: "index.htm",
             uri_query: None,
-            #[cfg(feature = "experimental")]
+            #[cfg(feature = "mem-cache")]
             memory_cache: None,
             #[cfg(feature = "directory-listing")]
             dir_listing: false,
@@ -113,7 +113,7 @@ mod tests {
             base_path: &root_dir(),
             uri_path: "index.htm",
             uri_query: None,
-            #[cfg(feature = "experimental")]
+            #[cfg(feature = "mem-cache")]
             memory_cache: None,
             #[cfg(feature = "directory-listing")]
             dir_listing: false,
@@ -165,7 +165,7 @@ mod tests {
                 base_path: &root_dir(),
                 uri_path: "xyz.html",
                 uri_query: None,
-                #[cfg(feature = "experimental")]
+                #[cfg(feature = "mem-cache")]
                 memory_cache: None,
                 #[cfg(feature = "directory-listing")]
                 dir_listing: false,
@@ -201,7 +201,7 @@ mod tests {
             base_path: &root_dir(),
             uri_path: "assets",
             uri_query: None,
-            #[cfg(feature = "experimental")]
+            #[cfg(feature = "mem-cache")]
             memory_cache: None,
             #[cfg(feature = "directory-listing")]
             dir_listing: false,
@@ -242,7 +242,7 @@ mod tests {
             base_path: &root_dir(),
             uri_path: "assets",
             uri_query: None,
-            #[cfg(feature = "experimental")]
+            #[cfg(feature = "mem-cache")]
             memory_cache: None,
             #[cfg(feature = "directory-listing")]
             dir_listing: false,
@@ -279,7 +279,7 @@ mod tests {
             base_path: &root_dir(),
             uri_path: "assets",
             uri_query: None,
-            #[cfg(feature = "experimental")]
+            #[cfg(feature = "mem-cache")]
             memory_cache: None,
             #[cfg(feature = "directory-listing")]
             dir_listing: false,
@@ -321,7 +321,7 @@ mod tests {
                     base_path: &root_dir(),
                     uri_path: uri,
                     uri_query: None,
-                    #[cfg(feature = "experimental")]
+                    #[cfg(feature = "mem-cache")]
                     memory_cache: None,
                     #[cfg(feature = "directory-listing")]
                     dir_listing: false,
@@ -381,7 +381,7 @@ mod tests {
                 base_path: &root_dir(),
                 uri_path: "/assets/index%2ehtml",
                 uri_query: None,
-                #[cfg(feature = "experimental")]
+                #[cfg(feature = "mem-cache")]
                 memory_cache: None,
                 #[cfg(feature = "directory-listing")]
                 dir_listing: false,
@@ -420,7 +420,7 @@ mod tests {
                 base_path: &root_dir(),
                 uri_path: "/%2E%2e.html",
                 uri_query: None,
-                #[cfg(feature = "experimental")]
+                #[cfg(feature = "mem-cache")]
                 memory_cache: None,
                 #[cfg(feature = "directory-listing")]
                 dir_listing: false,
@@ -461,7 +461,7 @@ mod tests {
                 base_path: &root_dir(),
                 uri_path: "index.htm",
                 uri_query: None,
-                #[cfg(feature = "experimental")]
+                #[cfg(feature = "mem-cache")]
                 memory_cache: None,
                 #[cfg(feature = "directory-listing")]
                 dir_listing: false,
@@ -503,7 +503,7 @@ mod tests {
                 base_path: &root_dir(),
                 uri_path: "index.htm",
                 uri_query: None,
-                #[cfg(feature = "experimental")]
+                #[cfg(feature = "mem-cache")]
                 memory_cache: None,
                 #[cfg(feature = "directory-listing")]
                 dir_listing: false,
@@ -551,7 +551,7 @@ mod tests {
                 base_path: &root_dir(),
                 uri_path: "index.htm",
                 uri_query: None,
-                #[cfg(feature = "experimental")]
+                #[cfg(feature = "mem-cache")]
                 memory_cache: None,
                 #[cfg(feature = "directory-listing")]
                 dir_listing: false,
@@ -597,7 +597,7 @@ mod tests {
                 base_path: &root_dir(),
                 uri_path: "index.htm",
                 uri_query: None,
-                #[cfg(feature = "experimental")]
+                #[cfg(feature = "mem-cache")]
                 memory_cache: None,
                 #[cfg(feature = "directory-listing")]
                 dir_listing: false,
@@ -638,7 +638,7 @@ mod tests {
                 base_path: &root_dir(),
                 uri_path: "index.htm",
                 uri_query: None,
-                #[cfg(feature = "experimental")]
+                #[cfg(feature = "mem-cache")]
                 memory_cache: None,
                 #[cfg(feature = "directory-listing")]
                 dir_listing: false,
@@ -678,7 +678,7 @@ mod tests {
                 base_path: &root_dir(),
                 uri_path: "index.htm",
                 uri_query: None,
-                #[cfg(feature = "experimental")]
+                #[cfg(feature = "mem-cache")]
                 memory_cache: None,
                 #[cfg(feature = "directory-listing")]
                 dir_listing: false,
@@ -725,7 +725,7 @@ mod tests {
                 base_path: &root_dir(),
                 uri_path: "index.htm",
                 uri_query: None,
-                #[cfg(feature = "experimental")]
+                #[cfg(feature = "mem-cache")]
                 memory_cache: None,
                 #[cfg(feature = "directory-listing")]
                 dir_listing: false,
@@ -815,7 +815,7 @@ mod tests {
                 base_path: &comp_root_dir(),
                 uri_path: "large-test.html",
                 uri_query: None,
-                #[cfg(feature = "experimental")]
+                #[cfg(feature = "mem-cache")]
                 memory_cache: None,
                 #[cfg(feature = "directory-listing")]
                 dir_listing: false,
@@ -890,7 +890,7 @@ mod tests {
                 base_path: &root_dir(),
                 uri_path: "index.htm",
                 uri_query: None,
-                #[cfg(feature = "experimental")]
+                #[cfg(feature = "mem-cache")]
                 memory_cache: None,
                 #[cfg(feature = "directory-listing")]
                 dir_listing: false,
@@ -947,7 +947,7 @@ mod tests {
                 base_path: &root_dir(),
                 uri_path: "assets/index.html",
                 uri_query: None,
-                #[cfg(feature = "experimental")]
+                #[cfg(feature = "mem-cache")]
                 memory_cache: None,
                 #[cfg(feature = "directory-listing")]
                 dir_listing: false,
@@ -1004,7 +1004,7 @@ mod tests {
                 base_path: &root_dir(),
                 uri_path: "assets/index.html",
                 uri_query: None,
-                #[cfg(feature = "experimental")]
+                #[cfg(feature = "mem-cache")]
                 memory_cache: None,
                 #[cfg(feature = "directory-listing")]
                 dir_listing: false,
@@ -1062,7 +1062,7 @@ mod tests {
                 base_path: &root_dir(),
                 uri_path: "index.htm",
                 uri_query: None,
-                #[cfg(feature = "experimental")]
+                #[cfg(feature = "mem-cache")]
                 memory_cache: None,
                 #[cfg(feature = "directory-listing")]
                 dir_listing: false,
@@ -1109,7 +1109,7 @@ mod tests {
                 base_path: &root_dir(),
                 uri_path: "assets/index.html",
                 uri_query: None,
-                #[cfg(feature = "experimental")]
+                #[cfg(feature = "mem-cache")]
                 memory_cache: None,
                 #[cfg(feature = "directory-listing")]
                 dir_listing: false,
@@ -1169,7 +1169,7 @@ mod tests {
                 base_path: &root_dir(),
                 uri_path: "assets/index.html",
                 uri_query: None,
-                #[cfg(feature = "experimental")]
+                #[cfg(feature = "mem-cache")]
                 memory_cache: None,
                 #[cfg(feature = "directory-listing")]
                 dir_listing: false,
@@ -1226,7 +1226,7 @@ mod tests {
                 base_path: &root_dir(),
                 uri_path: "index.htm",
                 uri_query: None,
-                #[cfg(feature = "experimental")]
+                #[cfg(feature = "mem-cache")]
                 memory_cache: None,
                 #[cfg(feature = "directory-listing")]
                 dir_listing: false,
@@ -1283,7 +1283,7 @@ mod tests {
                 base_path: &root_dir(),
                 uri_path: "index.htm",
                 uri_query: None,
-                #[cfg(feature = "experimental")]
+                #[cfg(feature = "mem-cache")]
                 memory_cache: None,
                 #[cfg(feature = "directory-listing")]
                 dir_listing: false,
@@ -1343,7 +1343,7 @@ mod tests {
                 base_path: &root_dir(),
                 uri_path: "assets/index.html",
                 uri_query: None,
-                #[cfg(feature = "experimental")]
+                #[cfg(feature = "mem-cache")]
                 memory_cache: None,
                 #[cfg(feature = "directory-listing")]
                 dir_listing: false,
@@ -1393,7 +1393,7 @@ mod tests {
                 base_path: &root_dir(),
                 uri_path: "index.htm",
                 uri_query: None,
-                #[cfg(feature = "experimental")]
+                #[cfg(feature = "mem-cache")]
                 memory_cache: None,
                 #[cfg(feature = "directory-listing")]
                 dir_listing: false,
@@ -1439,7 +1439,7 @@ mod tests {
                 base_path: &root_dir(),
                 uri_path: "assets/index.html",
                 uri_query: None,
-                #[cfg(feature = "experimental")]
+                #[cfg(feature = "mem-cache")]
                 memory_cache: None,
                 #[cfg(feature = "directory-listing")]
                 dir_listing: false,
@@ -1503,7 +1503,7 @@ mod tests {
                 base_path: &root_dir(),
                 uri_path: "assets/index.html",
                 uri_query: None,
-                #[cfg(feature = "experimental")]
+                #[cfg(feature = "mem-cache")]
                 memory_cache: None,
                 #[cfg(feature = "directory-listing")]
                 dir_listing: false,
@@ -1559,7 +1559,7 @@ mod tests {
                 base_path: &root_dir,
                 uri_path: ".dotfile",
                 uri_query: None,
-                #[cfg(feature = "experimental")]
+                #[cfg(feature = "mem-cache")]
                 memory_cache: None,
                 #[cfg(feature = "directory-listing")]
                 dir_listing: false,
@@ -1599,7 +1599,7 @@ mod tests {
                 base_path: &root_dir,
                 uri_path: "foo.html",
                 uri_query: None,
-                #[cfg(feature = "experimental")]
+                #[cfg(feature = "mem-cache")]
                 memory_cache: None,
                 #[cfg(feature = "directory-listing")]
                 dir_listing: false,
@@ -1655,7 +1655,7 @@ mod tests {
                 base_path: &root_dir,
                 uri_path: ".hidden-file.txt",
                 uri_query: None,
-                #[cfg(feature = "experimental")]
+                #[cfg(feature = "mem-cache")]
                 memory_cache: None,
                 #[cfg(feature = "directory-listing")]
                 dir_listing: false,
@@ -1699,7 +1699,7 @@ mod tests {
                 base_path: &root_dir,
                 uri_path: "/",
                 uri_query: None,
-                #[cfg(feature = "experimental")]
+                #[cfg(feature = "mem-cache")]
                 memory_cache: None,
                 #[cfg(feature = "directory-listing")]
                 dir_listing: false,
@@ -1748,7 +1748,7 @@ mod tests {
                 base_path: &root_dir,
                 uri_path: "/symlink",
                 uri_query: None,
-                #[cfg(feature = "experimental")]
+                #[cfg(feature = "mem-cache")]
                 memory_cache: None,
                 #[cfg(feature = "directory-listing")]
                 dir_listing: false,
@@ -1784,7 +1784,7 @@ mod tests {
                 base_path: &root_dir,
                 uri_path: "/symlink/spécial file.txt~",
                 uri_query: None,
-                #[cfg(feature = "experimental")]
+                #[cfg(feature = "mem-cache")]
                 memory_cache: None,
                 #[cfg(feature = "directory-listing")]
                 dir_listing: false,
@@ -1830,7 +1830,7 @@ mod tests {
                     base_path: &root_dir,
                     uri_path: "/readme.md",
                     uri_query: None,
-                    #[cfg(feature = "experimental")]
+                    #[cfg(feature = "mem-cache")]
                     memory_cache: None,
                     #[cfg(feature = "directory-listing")]
                     dir_listing: false,
@@ -1877,7 +1877,7 @@ mod tests {
                     base_path: &root_dir,
                     uri_path: "/unknown.md",
                     uri_query: None,
-                    #[cfg(feature = "experimental")]
+                    #[cfg(feature = "mem-cache")]
                     memory_cache: None,
                     #[cfg(feature = "directory-listing")]
                     dir_listing: false,

--- a/tests/tls.rs
+++ b/tests/tls.rs
@@ -152,9 +152,7 @@ mod settings_tests {
     }
 }
 
-// ---------------------------------------------------------------------------
 // Live server integration tests
-// ---------------------------------------------------------------------------
 //
 // Each test spawns a real SWS server in a dedicated thread (with its own tokio
 // runtime) and connects to it using a TLS client. To avoid flakiness:

--- a/tests/tls.rs
+++ b/tests/tls.rs
@@ -186,16 +186,16 @@ mod test_helpers {
 
     /// Wait until the server is accepting TCP connections on `port`.
     pub async fn wait_for_server(port: u16) {
-        for _ in 0..50 {
+        for _ in 0..100 {
             if tokio::net::TcpStream::connect(("127.0.0.1", port))
                 .await
                 .is_ok()
             {
                 return;
             }
-            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
         }
-        panic!("server did not become ready on port {port} within 2.5s");
+        panic!("server did not become ready on port {port} within 10s");
     }
 
     /// Build a rustls `ClientConfig` that skips certificate verification (safe

--- a/tests/toml/memory_cache.toml
+++ b/tests/toml/memory_cache.toml
@@ -1,0 +1,14 @@
+[general]
+host = "127.0.0.1"
+port = 8787
+root = "tests/fixtures/public"
+
+[advanced.memory-cache]
+# Cap entry count for the in-memory store.
+capacity = 50
+# 10 minutes
+ttl = 600
+# 2 minutes
+tti = 120
+# 4 KiB; small enough to exercise the per-file size cap.
+max-file-size = 4


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Read the docs/PULL_REQUESTS.md -->

## Description
<!--- Describe your changes but try to be as concise as possible -->

This PR stabilizes the experimental In-Memory Cache feature (https://github.com/static-web-server/static-web-server/pull/328).

The feature also supports expiration policies such as _Time To Live_ (TTL) and _Time To Idle_ (TTI).

Admission to a cache is controlled by the _Least Frequently Used_ (LFU) policy and the eviction from a cache is controlled by the _Least Recently Used_ (LRU) policy.

For details about the options supported, see [the cache library docs](https://docs.rs/mini-moka/latest/mini_moka/).

Configuration example:

```toml
[general]

[advanced]

[advanced.memory-cache]
# Maximum capacity entries of the memory cache-store. Default 256
capacity = 256
# Time to live in seconds of a cached file entry. Default 1h
ttl = 3600
# Time to idle in seconds of a cached file entry. Default 5min
tti = 300
# Maximum size in bytes for a file entry to be cached. Default 8MB
max-file-size = 8192
```

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Resolves #242

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- See how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
