### PR TITLE
Hardening and robustness increase for several modules (backport)

### DIFF
--- a/src/basic_auth.rs
+++ b/src/basic_auth.rs
@@ -49,9 +49,9 @@ pub(crate) fn pre_process<T>(
         if let Ok(ref mut resp) = result {
             resp.headers_mut().insert(
                 WWW_AUTHENTICATE,
-                "Basic realm=\"Static Web Server\", charset=\"UTF-8\""
-                    .parse()
-                    .unwrap(),
+                hyper::header::HeaderValue::from_static(
+                    "Basic realm=\"Static Web Server\", charset=\"UTF-8\"",
+                ),
             );
         }
         Some(result)

--- a/src/directory_listing_download.rs
+++ b/src/directory_listing_download.rs
@@ -174,13 +174,17 @@ where
     let mut resp = Response::new(Body::empty());
 
     resp.headers_mut().typed_insert(ContentType::from(
-        // since this satisfies the required format: `*/*`, it should not fail
-        Mime::from_str("application/gzip").unwrap(),
+        Mime::from_str("application/gzip").unwrap_or(mime_guess::mime::APPLICATION_OCTET_STREAM),
     ));
-    let hvals = format!(
-        "attachment; filename=\"{}\"",
-        archive_name.to_string_lossy()
-    );
+
+    // A safe `Content-Disposition` value that combines an
+    // ASCII-safe quoted-string `filename=...` (for legacy user agents) and
+    // an RFC 5987 `filename*=UTF-8''<percent-encoded>` (for modern UAs).
+    let archive_name_str = archive_name.to_string_lossy();
+    let ascii_safe = sanitize_filename_for_quoted_string(&archive_name_str);
+    let percent_encoded = rfc5987_encode_filename(&archive_name_str);
+    let hvals =
+        format!("attachment; filename=\"{ascii_safe}\"; filename*=UTF-8''{percent_encoded}");
     match HeaderValue::from_str(hvals.as_str()) {
         Ok(hval) => {
             resp.headers_mut()
@@ -209,4 +213,118 @@ where
     *resp.body_mut() = body;
 
     resp
+}
+
+/// Sanitize a filename for use inside an HTTP `Content-Disposition`
+/// `filename="..."` quoted-string. Strips characters that would break the
+/// quoted-string framing (`"`, `\`) or HTTP header parsing (`\r`, `\n`, NUL,
+/// and other ASCII control bytes), and replaces any non-ASCII byte with
+/// `_`. The lossy ASCII filename is paired with an RFC 5987 `filename*=`
+/// variant carrying the full UTF-8 name (see `rfc5987_encode_filename`).
+#[doc(hidden)]
+pub fn sanitize_filename_for_quoted_string(name: &str) -> String {
+    let mut out = String::with_capacity(name.len());
+    for ch in name.chars() {
+        match ch {
+            '"' | '\\' => out.push('_'),
+            c if (c as u32) < 0x20 || c == '\x7f' => out.push('_'),
+            c if c.is_ascii() => out.push(c),
+            _ => out.push('_'),
+        }
+    }
+    if out.is_empty() {
+        out.push_str("download");
+    }
+    out
+}
+
+/// Percent-encode a filename per RFC 5987 (the `attr-char` production
+/// from RFC 8187). Used as the `filename*=UTF-8''<value>` parameter so
+/// non-ASCII filenames survive transit to modern user agents.
+#[doc(hidden)]
+pub fn rfc5987_encode_filename(name: &str) -> String {
+    // RFC 8187 `attr-char` allows: ALPHA / DIGIT and `! # $ & + - . ^ _ ` | ~`
+    // Everything else (including `"`, `\`, space, control bytes, and any
+    // non-ASCII byte) is percent-encoded as `%HH`.
+    fn is_attr_char(b: u8) -> bool {
+        b.is_ascii_alphanumeric()
+            || matches!(
+                b,
+                b'!' | b'#' | b'$' | b'&' | b'+' | b'-' | b'.' | b'^' | b'_' | b'`' | b'|' | b'~'
+            )
+    }
+    let mut out = String::with_capacity(name.len());
+    for &b in name.as_bytes() {
+        if is_attr_char(b) {
+            out.push(b as char);
+        } else {
+            use std::fmt::Write;
+            let _ = write!(out, "%{b:02X}");
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{rfc5987_encode_filename, sanitize_filename_for_quoted_string};
+
+    /// SECURITY: A directory name containing `"` or `\` must NOT break out
+    /// of the `Content-Disposition` quoted-string framing.
+    #[test]
+    fn sanitize_strips_quote_and_backslash() {
+        let out = sanitize_filename_for_quoted_string("evil\".tar.gz");
+        assert!(!out.contains('"'));
+        let out2 = sanitize_filename_for_quoted_string("a\\b.tar.gz");
+        assert!(!out2.contains('\\'));
+    }
+
+    /// SECURITY: Control bytes (CR/LF/NUL) must not survive into a header
+    /// value — they could be reflected if a downstream proxy mishandles
+    /// `Content-Disposition`.
+    #[test]
+    fn sanitize_strips_control_bytes() {
+        let out = sanitize_filename_for_quoted_string("a\r\nb\tc\x00d");
+        for ch in out.chars() {
+            assert!(
+                ch as u32 >= 0x20 && ch != '\x7f',
+                "control byte leaked: {:?}",
+                ch
+            );
+        }
+    }
+
+    /// Non-ASCII characters are dropped from the quoted-string variant
+    /// (browsers fall back to the `filename*=UTF-8''...` parameter for
+    /// these).
+    #[test]
+    fn sanitize_replaces_non_ascii() {
+        let out = sanitize_filename_for_quoted_string("rep\u{00f6}rt.tar.gz");
+        assert!(out.is_ascii());
+        assert!(out.starts_with("rep_rt") || out.starts_with("rep__rt"));
+    }
+
+    #[test]
+    fn sanitize_never_empty() {
+        assert_eq!(sanitize_filename_for_quoted_string(""), "download");
+    }
+
+    /// RFC 5987 / RFC 8187 attr-char alphabet must round-trip unchanged.
+    #[test]
+    fn rfc5987_preserves_attr_char_alphabet() {
+        let input = "abcXYZ0189!#$&+-.^_`|~";
+        assert_eq!(rfc5987_encode_filename(input), input);
+    }
+
+    /// Everything outside attr-char must be percent-encoded — in
+    /// particular, `"`, `\`, space, CR, LF, and any non-ASCII byte.
+    #[test]
+    fn rfc5987_encodes_unsafe_bytes() {
+        assert_eq!(rfc5987_encode_filename("a b"), "a%20b");
+        assert_eq!(rfc5987_encode_filename("a\"b"), "a%22b");
+        assert_eq!(rfc5987_encode_filename("a\\b"), "a%5Cb");
+        assert_eq!(rfc5987_encode_filename("a\r\nb"), "a%0D%0Ab");
+        // UTF-8 `\u{00f6}` = 0xC3 0xB6
+        assert_eq!(rfc5987_encode_filename("\u{00f6}"), "%C3%B6");
+    }
 }

--- a/src/health.rs
+++ b/src/health.rs
@@ -37,7 +37,7 @@ pub fn pre_process<T>(
     };
 
     let mut resp = Response::new(body);
-    resp.headers_mut().typed_insert(ContentType::html());
+    resp.headers_mut().typed_insert(ContentType::text_utf8());
     Some(Ok(resp))
 }
 

--- a/src/https_redirect.rs
+++ b/src/https_redirect.rs
@@ -7,7 +7,10 @@
 //!
 
 use headers::{HeaderMapExt, Host};
-use hyper::{Body, Request, Response, StatusCode, header::LOCATION};
+use hyper::{
+    Body, Request, Response, StatusCode,
+    header::{HeaderValue, LOCATION},
+};
 use std::sync::Arc;
 
 use crate::Result;
@@ -46,9 +49,17 @@ pub fn redirect_to_https<T>(
         );
         tracing::debug!("https redirect to {}", url);
 
+        let location = match HeaderValue::from_str(&url) {
+            Ok(location) => location,
+            Err(err) => {
+                tracing::error!("invalid https redirect location `{url}`: {err:?}");
+                return Err(StatusCode::BAD_REQUEST);
+            }
+        };
+
         let mut resp = Response::new(Body::empty());
         *resp.status_mut() = StatusCode::MOVED_PERMANENTLY;
-        resp.headers_mut().insert(LOCATION, url.parse().unwrap());
+        resp.headers_mut().insert(LOCATION, location);
         return Ok(resp);
     }
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -77,9 +77,24 @@ static HTTP_CONNECTIONS_ACTIVE: LazyLock<IntGauge> = LazyLock::new(|| {
 /// Initializes the metrics endpoint and registers HTTP-level collectors.
 /// Tokio runtime metrics are additionally registered when the `experimental`
 /// feature is enabled and built with `RUSTFLAGS="--cfg tokio_unstable"`.
+///
+/// # Security
+///
+/// The `/metrics` endpoint is exposed **without any built-in access
+/// control** — it is intentionally unauthenticated so that a sidecar
+/// Prometheus scraper can reach it cheaply. Operators MUST place SWS
+/// behind a reverse proxy or network policy that restricts `/metrics`
+/// to trusted scrapers; otherwise an unauthenticated client could
+/// enumerate vhost names, request volumes, and latency distributions
+/// (information disclosure).
 pub fn init(enabled: bool, handler_opts: &mut RequestHandlerOpts) {
     handler_opts.metrics_enabled = enabled;
     tracing::info!("metrics endpoint: enabled={enabled}");
+    if enabled {
+        tracing::warn!(
+            "metrics endpoint `/metrics` is unauthenticated; restrict access via reverse proxy or network policy"
+        );
+    }
 
     if enabled {
         let registry = default_registry();
@@ -87,30 +102,30 @@ pub fn init(enabled: bool, handler_opts: &mut RequestHandlerOpts) {
         // Tokio runtime metrics (experimental, unix-only, requires tokio_unstable)
         #[cfg(all(unix, feature = "experimental"))]
         {
-            registry
-                .register(Box::new(
-                    tokio_metrics_collector::default_runtime_collector(),
-                ))
-                .unwrap();
+            if let Err(err) = registry.register(Box::new(
+                tokio_metrics_collector::default_runtime_collector(),
+            )) {
+                tracing::debug!("tokio runtime metrics collector registration skipped: {err:?}");
+            }
             tracing::info!("tokio runtime metrics: enabled");
         }
 
         // HTTP-level metrics
-        registry
-            .register(Box::new(HTTP_REQUESTS_TOTAL.clone()))
-            .unwrap();
-        registry
-            .register(Box::new(HTTP_REQUEST_DURATION_SECONDS.clone()))
-            .unwrap();
-        registry
-            .register(Box::new(HTTP_RESPONSE_BYTES_TOTAL.clone()))
-            .unwrap();
-        registry
-            .register(Box::new(HTTP_REQUESTS_INFLIGHT.clone()))
-            .unwrap();
-        registry
-            .register(Box::new(HTTP_CONNECTIONS_ACTIVE.clone()))
-            .unwrap();
+        if let Err(err) = registry.register(Box::new(HTTP_REQUESTS_TOTAL.clone())) {
+            tracing::debug!("metrics collector registration skipped: {err:?}");
+        }
+        if let Err(err) = registry.register(Box::new(HTTP_REQUEST_DURATION_SECONDS.clone())) {
+            tracing::debug!("metrics collector registration skipped: {err:?}");
+        }
+        if let Err(err) = registry.register(Box::new(HTTP_RESPONSE_BYTES_TOTAL.clone())) {
+            tracing::debug!("metrics collector registration skipped: {err:?}");
+        }
+        if let Err(err) = registry.register(Box::new(HTTP_REQUESTS_INFLIGHT.clone())) {
+            tracing::debug!("metrics collector registration skipped: {err:?}");
+        }
+        if let Err(err) = registry.register(Box::new(HTTP_CONNECTIONS_ACTIVE.clone())) {
+            tracing::debug!("metrics collector registration skipped: {err:?}");
+        }
     }
 }
 
@@ -136,10 +151,19 @@ pub fn pre_process<T>(
     let body = if method.is_get() {
         let encoder = TextEncoder::new();
         let mut buffer = Vec::new();
-        encoder
-            .encode(&default_registry().gather(), &mut buffer)
-            .unwrap();
-        let data = String::from_utf8(buffer).unwrap();
+        if let Err(err) = encoder.encode(&default_registry().gather(), &mut buffer) {
+            return Some(Err(
+                Error::new(err).context("failed to encode metrics output")
+            ));
+        }
+        let data = match String::from_utf8(buffer) {
+            Ok(data) => data,
+            Err(err) => {
+                return Some(Err(
+                    Error::new(err).context("metrics output was not valid UTF-8")
+                ));
+            }
+        };
         Body::from(data)
     } else {
         Body::empty()

--- a/src/redirects.rs
+++ b/src/redirects.rs
@@ -5,12 +5,32 @@
 
 //! Redirection module to handle config redirect URLs with pattern matching support.
 //!
+//! # Security: ReDoS / pattern complexity
+//!
+//! Redirect/rewrite source patterns are admin-supplied at startup. SWS
+//! uses [`regex_lite`], which has **no backtracking** (linear-time NFA
+//! engine), so the classic catastrophic-backtracking ReDoS class does
+//! not apply. However:
+//!
+//! - Per-request work is still proportional to `pattern_size * uri_len`.
+//!   To bound it, requests with URIs longer than [`MAX_URI_LEN_FOR_REGEX`]
+//!   bytes are skipped (no regex evaluation, no redirect).
+//! - Operators should treat redirect patterns as trusted configuration
+//!   and avoid loading them from untrusted sources.
 
 use headers::HeaderValue;
 use hyper::{Body, Request, Response, StatusCode};
 use regex_lite::Regex;
 
 use crate::{Error, error_page, handler::RequestHandlerOpts, settings::Redirects};
+
+/// Maximum URI length (bytes) that will be fed to the redirect regex
+/// engine. Requests above this size skip redirect matching entirely.
+///
+/// 8 KiB matches the common HTTP-server URI cap and is more than the
+/// largest realistic redirect source while still bounding per-request
+/// regex work to a small constant.
+pub(crate) const MAX_URI_LEN_FOR_REGEX: usize = 8 * 1024;
 
 /// Applies redirect rules to a request if necessary.
 pub(crate) fn pre_process<T>(
@@ -21,6 +41,16 @@ pub(crate) fn pre_process<T>(
 
     let uri = req.uri();
     let uri_path = uri.path();
+    // Refuse to run any regex against unreasonably long URIs.
+    // See module-level docs.
+    if uri_path.len() > MAX_URI_LEN_FOR_REGEX {
+        tracing::debug!(
+            "redirects: skipping match, uri path length {} exceeds cap {}",
+            uri_path.len(),
+            MAX_URI_LEN_FOR_REGEX
+        );
+        return None;
+    }
     let host = req
         .headers()
         .get(http::header::HOST)

--- a/src/rewrites.rs
+++ b/src/rewrites.rs
@@ -12,7 +12,7 @@ use hyper::{Body, Request, Response, StatusCode, Uri, header::HOST};
 use crate::{
     Error,
     handler::RequestHandlerOpts,
-    redirects::{handle_error, replace_placeholders},
+    redirects::{MAX_URI_LEN_FOR_REGEX, handle_error, replace_placeholders},
     settings::{Rewrites, file::RedirectsKind},
 };
 
@@ -23,6 +23,14 @@ pub(crate) fn pre_process<T>(
 ) -> Option<Result<Response<Body>, Error>> {
     let rewrites = opts.advanced_opts.as_ref()?.rewrites.as_deref()?;
     let uri_path = req.uri().path();
+    if uri_path.len() > MAX_URI_LEN_FOR_REGEX {
+        tracing::debug!(
+            "rewrites: skipping match, uri path length {} exceeds cap {}",
+            uri_path.len(),
+            MAX_URI_LEN_FOR_REGEX
+        );
+        return None;
+    }
 
     let matched = rewrite_uri_path(uri_path, Some(rewrites))?;
     let dest = match replace_placeholders(uri_path, &matched.source, &matched.destination) {

--- a/src/server.rs
+++ b/src/server.rs
@@ -392,9 +392,10 @@ impl Server {
         let ctrlc_task = tokio::spawn(async move {
             if !general.windows_service {
                 tracing::info!("installing graceful shutdown ctrl+c signal handler");
-                tokio::signal::ctrl_c()
-                    .await
-                    .expect("failed to install ctrl+c signal handler");
+                if let Err(err) = tokio::signal::ctrl_c().await {
+                    tracing::error!("failed to install ctrl+c signal handler: {err:?}");
+                    return;
+                }
                 tracing::info!("installing graceful shutdown ctrl+c signal handler");
                 let _ = sender.send(());
             }

--- a/src/settings/file.rs
+++ b/src/settings/file.rs
@@ -413,8 +413,7 @@ impl Settings {
     /// Read and deserialize the server TOML configuration file by path.
     pub fn read(config_file: &Path) -> Result<Settings> {
         // Validate TOML file extension
-        let ext = config_file.extension();
-        if ext.is_none() || ext.unwrap().is_empty() || ext.unwrap().ne("toml") {
+        if !matches!(config_file.extension(), Some(ext) if !ext.is_empty() && ext == "toml") {
             bail!("configuration file should be in toml format. E.g `sws.toml`");
         }
 

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -234,9 +234,7 @@ impl Settings {
 
             // File-based "general" options
             let has_general_settings = settings.general.is_some();
-            if has_general_settings {
-                let general = settings.general.unwrap();
-
+            if let Some(general) = settings.general {
                 if let Some(v) = general.host {
                     host = v
                 }

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -191,7 +191,10 @@ impl LazyFile {
             self.file = Some(File::open(&self.path)?);
         }
 
-        self.file.as_mut().unwrap().read(buf)
+        match self.file.as_mut() {
+            Some(file) => file.read(buf),
+            None => Err(io::Error::other("file handle unavailable after open")),
+        }
     }
 }
 

--- a/src/virtual_hosts.rs
+++ b/src/virtual_hosts.rs
@@ -43,7 +43,7 @@ pub(crate) fn get_real_root<'a, T>(
 
     for vhost in vhosts {
         if vhost.host == request_host_str {
-            tracing::info!(
+            tracing::debug!(
                 "virtual host matched: vhost={} vhost_root={} method={} uri={}",
                 vhost.host,
                 vhost.root.display(),

--- a/src/winservice.rs
+++ b/src/winservice.rs
@@ -93,7 +93,7 @@ fn run_service() -> Result {
                 tracing::debug!("windows service: handled 'ServiceControl::Stop' event");
                 if let Some(sender) = shutdown_tx.take() {
                     tracing::debug!("windows service: delegated 'ServiceControl::Stop' event");
-                    sender.send(()).unwrap();
+                    let _ = sender.send(());
                 }
                 ServiceControlHandlerResult::NoError
             }
@@ -162,9 +162,14 @@ fn run_service() -> Result {
 /// Run web server as Windows Server
 pub fn run_server_as_service() -> Result {
     // Set current directory to the same as the executable
-    let mut path = env::current_exe().unwrap();
+    let mut path = env::current_exe().with_context(|| "error getting current executable path")?;
     path.pop();
-    env::set_current_dir(&path).unwrap();
+    env::set_current_dir(&path).with_context(|| {
+        format!(
+            "error setting current directory to executable directory `{}`",
+            path.display()
+        )
+    })?;
 
     // Register generated `ffi_service_main` with the system and start the
     // service, blocking this thread until the service is stopped
@@ -179,7 +184,9 @@ pub fn install_service(config_file: &Path) -> Result {
     let service_manager = ServiceManager::local_computer(None::<&str>, manager_access)?;
 
     // Set the executable path to point the current binary
-    let service_binary_path = std::env::current_exe().unwrap().with_file_name(SERVICE_EXE);
+    let service_binary_path = std::env::current_exe()
+        .with_context(|| "error getting current executable path")?
+        .with_file_name(SERVICE_EXE);
 
     // Set service binary default arguments
     let mut service_binary_arguments = vec![OsString::from("--windows-service=true")];


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->
<!--- Read the docs/PULL_REQUESTS.md -->

## Description
<!--- Describe your changes but try to be as concise as possible -->

This PR  removes several potential panics and increase robustness across multiple modules such as `basic_auth`, `directory_listing_download`, `health`, `https_redirect`, `metrics`, `redirects`, `rewrites`, `server`, `settings`, `tls`, `virtual_hosts`, and `winservice`.

It is a backport of v3 (70549d9). See PR https://github.com/static-web-server/static-web-server/pull/668

**Changelog**

- Replace `unwrap`/`expect` with proper error handling or safe fallbacks.
- Add `Content-Disposition` sanitization helpers for directory downloads.
- Add URI length cap (8 KiB) for redirect/rewrite regex evaluation.
- Demote virtual host per-request log from info to `debug` level.
- Change health endpoint `Content-Type` to `text/plain`.
- Add security warning about unauthenticated `/metrics` endpoint.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- See how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
