### PR TITLE
Minimum size threshold for dynamic compression (backport)

### DIFF
--- a/src/compression.rs
+++ b/src/compression.rs
@@ -39,6 +39,9 @@ use crate::{
     settings::CompressionLevel,
 };
 
+/// Minimum response body size in bytes below which dynamic compression is skipped.
+const MIN_COMPRESS_SIZE: usize = 200;
+
 /// List of encodings that can be handled given enabled features.
 const AVAILABLE_ENCODINGS: &[ContentCoding] = &[
     #[cfg(any(feature = "compression", feature = "compression-deflate"))]
@@ -145,6 +148,22 @@ pub fn auto(
         if let Some(content_type) = resp.headers().typed_get::<ContentType>()
             && !Mime::from(content_type).is_compressible()
         {
+            return Ok(resp);
+        }
+
+        // Skip compression for responses below the minimum size threshold.
+        // Tiny payloads gain no benefit and the compression overhead can
+        // make them larger than the original.
+        if let Some(content_length) = resp
+            .headers()
+            .get(CONTENT_LENGTH)
+            .and_then(|v| v.to_str().ok())
+            .and_then(|v| v.parse::<usize>().ok())
+            && content_length < MIN_COMPRESS_SIZE
+        {
+            tracing::trace!(
+                "skipping compression: content-length ({content_length}) below minimum ({MIN_COMPRESS_SIZE})",
+            );
             return Ok(resp);
         }
 
@@ -364,5 +383,112 @@ impl From<Body> for CompressableBody<Body, hyper::Error> {
     #[inline(always)]
     fn from(body: Body) -> Self {
         CompressableBody { body }
+    }
+}
+
+#[cfg(test)]
+#[cfg(any(feature = "compression", feature = "compression-gzip"))]
+mod tests {
+    use super::*;
+    use http::header::{ACCEPT_ENCODING, CONTENT_TYPE};
+
+    fn text_response_with_size(size: usize) -> Response<Body> {
+        let mut resp = Response::new(Body::from(vec![b'x'; size]));
+        resp.headers_mut()
+            .insert(CONTENT_TYPE, "text/html".parse().unwrap());
+        resp.headers_mut()
+            .insert(CONTENT_LENGTH, size.to_string().parse().unwrap());
+        resp
+    }
+
+    fn text_response_without_length() -> Response<Body> {
+        let mut resp = Response::new(Body::from("hello world"));
+        resp.headers_mut()
+            .insert(CONTENT_TYPE, "text/html".parse().unwrap());
+        resp
+    }
+
+    fn accept_gzip_headers() -> HeaderMap<HeaderValue> {
+        let mut headers = HeaderMap::new();
+        headers.insert(ACCEPT_ENCODING, "gzip".parse().unwrap());
+        headers
+    }
+
+    #[test]
+    fn small_response_below_threshold_is_not_compressed() {
+        let resp = text_response_with_size(MIN_COMPRESS_SIZE - 1);
+        let headers = accept_gzip_headers();
+        let result = auto(&Method::GET, &headers, CompressionLevel::Default, resp).unwrap();
+
+        assert!(
+            result.headers().get(CONTENT_ENCODING).is_none(),
+            "responses below {MIN_COMPRESS_SIZE} bytes must not be compressed"
+        );
+    }
+
+    #[test]
+    fn response_at_threshold_is_compressed() {
+        let resp = text_response_with_size(MIN_COMPRESS_SIZE);
+        let headers = accept_gzip_headers();
+        let result = auto(&Method::GET, &headers, CompressionLevel::Default, resp).unwrap();
+
+        assert!(
+            result.headers().get(CONTENT_ENCODING).is_some(),
+            "responses at exactly {MIN_COMPRESS_SIZE} bytes must be compressed"
+        );
+    }
+
+    #[test]
+    fn response_above_threshold_is_compressed() {
+        let resp = text_response_with_size(MIN_COMPRESS_SIZE + 1);
+        let headers = accept_gzip_headers();
+        let result = auto(&Method::GET, &headers, CompressionLevel::Default, resp).unwrap();
+
+        assert!(
+            result.headers().get(CONTENT_ENCODING).is_some(),
+            "responses above {MIN_COMPRESS_SIZE} bytes must be compressed"
+        );
+    }
+
+    #[test]
+    fn response_without_content_length_is_compressed() {
+        let resp = text_response_without_length();
+        let headers = accept_gzip_headers();
+        let result = auto(&Method::GET, &headers, CompressionLevel::Default, resp).unwrap();
+
+        assert!(
+            result.headers().get(CONTENT_ENCODING).is_some(),
+            "responses without Content-Length must still be compressed"
+        );
+    }
+
+    #[test]
+    fn small_response_head_method_is_not_compressed() {
+        let resp = text_response_with_size(MIN_COMPRESS_SIZE - 1);
+        let headers = accept_gzip_headers();
+        let result = auto(&Method::HEAD, &headers, CompressionLevel::Default, resp).unwrap();
+
+        assert!(
+            result.headers().get(CONTENT_ENCODING).is_none(),
+            "HEAD requests are never compressed regardless of size"
+        );
+    }
+
+    #[test]
+    fn non_compressible_content_type_is_not_compressed() {
+        let mut resp = Response::new(Body::from(vec![b'x'; MIN_COMPRESS_SIZE + 100]));
+        resp.headers_mut()
+            .insert(CONTENT_TYPE, "image/png".parse().unwrap());
+        resp.headers_mut().insert(
+            CONTENT_LENGTH,
+            (MIN_COMPRESS_SIZE + 100).to_string().parse().unwrap(),
+        );
+        let headers = accept_gzip_headers();
+        let result = auto(&Method::GET, &headers, CompressionLevel::Default, resp).unwrap();
+
+        assert!(
+            result.headers().get(CONTENT_ENCODING).is_none(),
+            "non-compressible content-types are never compressed"
+        );
     }
 }

--- a/src/redirects.rs
+++ b/src/redirects.rs
@@ -13,8 +13,8 @@
 //! not apply. However:
 //!
 //! - Per-request work is still proportional to `pattern_size * uri_len`.
-//!   To bound it, requests with URIs longer than [`MAX_URI_LEN_FOR_REGEX`]
-//!   bytes are skipped (no regex evaluation, no redirect).
+//!   To bound it, requests with URI paths longer than the internal matching cap
+//!   are skipped (no regex evaluation, no redirect).
 //! - Operators should treat redirect patterns as trusted configuration
 //!   and avoid loading them from untrusted sources.
 

--- a/tests/fixtures/compression/large-test.html
+++ b/tests/fixtures/compression/large-test.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Compression Test</title>
+</head>
+<body>
+<p>Paragraph 0: This is a test paragraph to make the file large enough for dynamic compression testing. It needs to be above the 200 byte threshold.</p>
+<p>Paragraph 1: This is a test paragraph to make the file large enough for dynamic compression testing. It needs to be above the 200 byte threshold.</p>
+<p>Paragraph 2: This is a test paragraph to make the file large enough for dynamic compression testing. It needs to be above the 200 byte threshold.</p>
+<p>Paragraph 3: This is a test paragraph to make the file large enough for dynamic compression testing. It needs to be above the 200 byte threshold.</p>
+<p>Paragraph 4: This is a test paragraph to make the file large enough for dynamic compression testing. It needs to be above the 200 byte threshold.</p>
+<p>Paragraph 5: This is a test paragraph to make the file large enough for dynamic compression testing. It needs to be above the 200 byte threshold.</p>
+<p>Paragraph 6: This is a test paragraph to make the file large enough for dynamic compression testing. It needs to be above the 200 byte threshold.</p>
+<p>Paragraph 7: This is a test paragraph to make the file large enough for dynamic compression testing. It needs to be above the 200 byte threshold.</p>
+<p>Paragraph 8: This is a test paragraph to make the file large enough for dynamic compression testing. It needs to be above the 200 byte threshold.</p>
+<p>Paragraph 9: This is a test paragraph to make the file large enough for dynamic compression testing. It needs to be above the 200 byte threshold.</p>
+<p>Paragraph 10: This is a test paragraph to make the file large enough for dynamic compression testing. It needs to be above the 200 byte threshold.</p>
+<p>Paragraph 11: This is a test paragraph to make the file large enough for dynamic compression testing. It needs to be above the 200 byte threshold.</p>
+<p>Paragraph 12: This is a test paragraph to make the file large enough for dynamic compression testing. It needs to be above the 200 byte threshold.</p>
+<p>Paragraph 13: This is a test paragraph to make the file large enough for dynamic compression testing. It needs to be above the 200 byte threshold.</p>
+<p>Paragraph 14: This is a test paragraph to make the file large enough for dynamic compression testing. It needs to be above the 200 byte threshold.</p>
+<p>Paragraph 15: This is a test paragraph to make the file large enough for dynamic compression testing. It needs to be above the 200 byte threshold.</p>
+<p>Paragraph 16: This is a test paragraph to make the file large enough for dynamic compression testing. It needs to be above the 200 byte threshold.</p>
+<p>Paragraph 17: This is a test paragraph to make the file large enough for dynamic compression testing. It needs to be above the 200 byte threshold.</p>
+<p>Paragraph 18: This is a test paragraph to make the file large enough for dynamic compression testing. It needs to be above the 200 byte threshold.</p>
+<p>Paragraph 19: This is a test paragraph to make the file large enough for dynamic compression testing. It needs to be above the 200 byte threshold.</p>
+</body>
+</html>

--- a/tests/static_files.rs
+++ b/tests/static_files.rs
@@ -29,6 +29,17 @@ mod tests {
         PathBuf::from("tests/fixtures/public/")
     }
 
+    #[cfg(any(
+        feature = "compression",
+        feature = "compression-deflate",
+        feature = "compression-gzip",
+        feature = "compression-brotli",
+        feature = "compression-zstd"
+    ))]
+    fn comp_root_dir() -> PathBuf {
+        PathBuf::from("tests/fixtures/compression/")
+    }
+
     const METHODS: [Method; 8] = [
         Method::CONNECT,
         Method::DELETE,
@@ -774,8 +785,8 @@ mod tests {
             match static_files::handle(&HandleOpts {
                 method,
                 headers: &headers,
-                base_path: &root_dir(),
-                uri_path: "index.htm",
+                base_path: &comp_root_dir(),
+                uri_path: "large-test.html",
                 uri_query: None,
                 #[cfg(feature = "experimental")]
                 memory_cache: None,
@@ -791,7 +802,7 @@ mod tests {
                 compression_static: false,
                 ignore_hidden_files: false,
                 disable_symlinks: false,
-                index_files: &["index.htm"],
+                index_files: &["large-test.html"],
             })
             .await
             {
@@ -805,8 +816,8 @@ mod tests {
                     )
                     .expect("unexpected bytes error during body compression");
 
-                    let buf = fs::read(root_dir().join("index.htm"))
-                        .expect("unexpected error during index.html reading");
+                    let buf = fs::read(comp_root_dir().join("large-test.html"))
+                        .expect("unexpected error during large-test.html reading");
 
                     assert_eq!(res.status(), 200);
                     assert_eq!(res.headers()["accept-ranges"], "bytes");


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Read the docs/PULL_REQUESTS.md -->

## Description
<!--- Describe your changes but try to be as concise as possible -->

This PR enables SWS to bypass dynamic compression for responses smaller than the minimum size threshold of 200 bytes.
As tiny payloads gain no benefit and the CPU compression overhead can make them larger than the original.

It is a backport (e4e3ab3) from v3 https://github.com/static-web-server/static-web-server/pull/661.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- See how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
