### PR TITLE
Performance optimizations for several modules (backport)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,6 +139,16 @@ panic = "abort"
 rpath = false
 strip = true
 
+# Same optimizations as `release` but with debug info and no stripping.
+# Use this profile when profiling with samply / Instruments / perf:
+#
+#   cargo build --profile release-profiling --features all
+#   samply record target/release-profiling/static-web-server -p 8787 -d docker/public/
+[profile.release-profiling]
+inherits = "release"
+debug = 2
+strip = false
+
 [package.metadata.docs.rs]
 features = ["all"]
 rustdoc-args = ["--cfg", "docsrs", "--cfg", "tokio_unstable"]

--- a/src/control_headers.rs
+++ b/src/control_headers.rs
@@ -7,14 +7,14 @@
 //! for incoming requests based on a set of file types.
 //!
 
-use hyper::{Body, Request, Response};
+use hyper::{Body, Request, Response, header::HeaderValue};
 
 use crate::{Error, handler::RequestHandlerOpts};
 
-// Cache-Control `max-age` variants
-const MAX_AGE_ONE_HOUR: u64 = 60 * 60;
-const MAX_AGE_ONE_DAY: u64 = 60 * 60 * 24;
-const MAX_AGE_ONE_YEAR: u64 = 60 * 60 * 24 * 365;
+// Pre-computed static Cache-Control header values
+static CACHE_CONTROL_ONE_HOUR: HeaderValue = HeaderValue::from_static("max-age=3600");
+static CACHE_CONTROL_ONE_DAY: HeaderValue = HeaderValue::from_static("max-age=86400");
+static CACHE_CONTROL_ONE_YEAR: HeaderValue = HeaderValue::from_static("max-age=31536000");
 
 // `Cache-Control` list of extensions
 const CACHE_EXT_ONE_HOUR: [&str; 4] = ["atom", "json", "rss", "xml"];
@@ -43,17 +43,9 @@ pub(crate) fn post_process<T>(
 
 /// It appends a `Cache-Control` header to a response if that one is part of a set of file types.
 pub fn append_headers(uri: &str, resp: &mut Response<Body>) {
-    let max_age = get_max_age(uri);
-    resp.headers_mut().insert(
-        "cache-control",
-        format!(
-            "max-age={}",
-            // It caps value in seconds at ~136 years
-            std::cmp::min(max_age, u32::MAX as u64)
-        )
-        .parse()
-        .unwrap(),
-    );
+    let header_value = get_cache_control_header(uri);
+    resp.headers_mut()
+        .insert("cache-control", header_value.clone());
 }
 
 /// Gets the file extension for a URI.
@@ -64,29 +56,24 @@ fn get_file_extension(uri: &str) -> Option<&str> {
     uri.rsplit_once('.').map(|(_, rest)| rest)
 }
 
+/// Returns the pre-computed static Cache-Control header value for the given URI.
 #[inline(always)]
-fn get_max_age(uri: &str) -> u64 {
-    // Default max-age value in seconds (one day)
-    let mut max_age = MAX_AGE_ONE_DAY;
-
+fn get_cache_control_header(uri: &str) -> &'static HeaderValue {
     if let Some(extension) = get_file_extension(uri) {
         if CACHE_EXT_ONE_HOUR.binary_search(&extension).is_ok() {
-            max_age = MAX_AGE_ONE_HOUR;
+            return &CACHE_CONTROL_ONE_HOUR;
         } else if CACHE_EXT_ONE_YEAR.binary_search(&extension).is_ok() {
-            max_age = MAX_AGE_ONE_YEAR;
+            return &CACHE_CONTROL_ONE_YEAR;
         }
     }
-    max_age
+    &CACHE_CONTROL_ONE_DAY
 }
 
 #[cfg(test)]
 mod tests {
     use hyper::{Body, Response, StatusCode};
 
-    use super::{
-        CACHE_EXT_ONE_HOUR, CACHE_EXT_ONE_YEAR, MAX_AGE_ONE_DAY, MAX_AGE_ONE_HOUR,
-        MAX_AGE_ONE_YEAR, append_headers, get_file_extension,
-    };
+    use super::{CACHE_EXT_ONE_HOUR, CACHE_EXT_ONE_YEAR, append_headers, get_file_extension};
 
     #[test]
     fn headers_one_hour() {
@@ -98,10 +85,7 @@ mod tests {
 
             let cache_control = resp.headers().get(http::header::CACHE_CONTROL).unwrap();
             assert_eq!(resp.status(), StatusCode::OK);
-            assert_eq!(
-                cache_control.to_str().unwrap(),
-                format!("max-age={MAX_AGE_ONE_HOUR}")
-            );
+            assert_eq!(cache_control.to_str().unwrap(), "max-age=3600");
         }
     }
 
@@ -114,10 +98,7 @@ mod tests {
 
         let cache_control = resp.headers().get(http::header::CACHE_CONTROL).unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
-        assert_eq!(
-            cache_control.to_str().unwrap(),
-            format!("max-age={MAX_AGE_ONE_DAY}")
-        );
+        assert_eq!(cache_control.to_str().unwrap(), "max-age=86400");
     }
 
     #[test]
@@ -130,10 +111,7 @@ mod tests {
 
             let cache_control = resp.headers().get(http::header::CACHE_CONTROL).unwrap();
             assert_eq!(resp.status(), StatusCode::OK);
-            assert_eq!(
-                cache_control.to_str().unwrap(),
-                format!("max-age={MAX_AGE_ONE_YEAR}")
-            );
+            assert_eq!(cache_control.to_str().unwrap(), "max-age=31536000");
         }
     }
 

--- a/src/cors.rs
+++ b/src/cors.rs
@@ -389,15 +389,24 @@ pub(crate) fn init(
     );
 }
 
+/// Cached CORS headers stored in request extensions to avoid
+/// re-validating the request in `post_process`.
+#[derive(Clone)]
+pub(crate) struct CorsHeaders(pub(crate) HeaderMap);
+
 /// Rejects requests with wrong CORS headers
 pub(crate) fn pre_process<T>(
     opts: &RequestHandlerOpts,
-    req: &Request<T>,
+    req: &mut Request<T>,
 ) -> Option<Result<Response<Body>, Error>> {
     let cors = opts.cors.as_ref()?;
     match cors.check_request(req.method(), req.headers()) {
-        Ok((_, state)) => {
+        Ok((headers, state)) => {
             tracing::debug!("cors state: {:?}", state);
+            // Stash validated headers for post_process to reuse
+            if !headers.is_empty() {
+                req.extensions_mut().insert(CorsHeaders(headers));
+            }
             None
         }
         Err(err) => {
@@ -419,11 +428,10 @@ pub(crate) fn post_process<T>(
     req: &Request<T>,
     mut resp: Response<Body>,
 ) -> Result<Response<Body>, Error> {
-    if let Some(cors) = opts.cors.as_ref()
-        && let Ok((headers, _)) = cors.check_request(req.method(), req.headers())
-        && !headers.is_empty()
+    if opts.cors.is_some()
+        && let Some(cors_headers) = req.extensions().get::<CorsHeaders>()
     {
-        for (k, v) in headers.iter() {
+        for (k, v) in cors_headers.0.iter() {
             resp.headers_mut().insert(k, v.to_owned());
         }
         resp.headers_mut().insert(
@@ -483,9 +491,9 @@ mod tests {
             cors: None,
             ..Default::default()
         };
-        let req = make_request("GET", "https://example.com/");
+        let mut req = make_request("GET", "https://example.com/");
 
-        assert!(pre_process(&opts, &req).is_none());
+        assert!(pre_process(&opts, &mut req).is_none());
 
         let resp = post_process(&opts, &req, make_response())?;
         assert_eq!(get_allowed_origin(resp), None);
@@ -499,9 +507,9 @@ mod tests {
             cors: make_cors_config(),
             ..Default::default()
         };
-        let req = make_request("GET", "");
+        let mut req = make_request("GET", "");
 
-        assert!(pre_process(&opts, &req).is_none());
+        assert!(pre_process(&opts, &mut req).is_none());
 
         let resp = post_process(&opts, &req, make_response())?;
         assert_eq!(get_allowed_origin(resp), None);
@@ -518,17 +526,17 @@ mod tests {
 
         assert!(is_403(pre_process(
             &opts,
-            &make_request("GET", "https://example.info")
+            &mut make_request("GET", "https://example.info")
         )));
         assert!(is_403(pre_process(
             &opts,
-            &make_request("OPTIONS", "https://example.com")
+            &mut make_request("OPTIONS", "https://example.com")
         )));
 
         let mut req = make_request("OPTIONS", "https://example.com");
         req.headers_mut()
             .insert("Access-Control-Request-Method", "POST".try_into().unwrap());
-        assert!(is_403(pre_process(&opts, &req)));
+        assert!(is_403(pre_process(&opts, &mut req)));
 
         let mut req = make_request("OPTIONS", "https://example.com");
         req.headers_mut()
@@ -537,7 +545,7 @@ mod tests {
             "Access-Control-Request-Headers",
             "X-Forbidden".try_into().unwrap(),
         );
-        assert!(is_403(pre_process(&opts, &req)));
+        assert!(is_403(pre_process(&opts, &mut req)));
     }
 
     #[test]
@@ -547,8 +555,8 @@ mod tests {
             ..Default::default()
         };
 
-        let req = make_request("GET", "https://example.com");
-        assert!(pre_process(&opts, &req).is_none());
+        let mut req = make_request("GET", "https://example.com");
+        assert!(pre_process(&opts, &mut req).is_none());
 
         let resp = post_process(&opts, &req, make_response())?;
         assert_eq!(get_allowed_origin(resp), Some("https://example.com".into()));
@@ -560,7 +568,7 @@ mod tests {
             "Access-Control-Request-Headers",
             "X-Allowed".try_into().unwrap(),
         );
-        assert!(pre_process(&opts, &req).is_none());
+        assert!(pre_process(&opts, &mut req).is_none());
 
         let resp = post_process(&opts, &req, make_response())?;
         assert_eq!(get_allowed_origin(resp), Some("https://example.com".into()));

--- a/src/fs/meta.rs
+++ b/src/fs/meta.rs
@@ -7,7 +7,7 @@
 //!
 
 use http::StatusCode;
-use std::fs::Metadata;
+use std::fs::{File, Metadata};
 use std::path::{Path, PathBuf};
 
 use crate::Result;
@@ -26,6 +26,12 @@ pub(crate) struct FileMetadata<'a> {
     pub is_dir: bool,
     // The precompressed file variant for the current `file_path`.
     pub precompressed_variant: Option<(PathBuf, ContentCoding)>,
+    /// An optional pre-opened `File` handle for `file_path`. When `Some`,
+    /// the response pipeline can reuse it instead of issuing another
+    /// `open(2)` syscall (the metadata was already obtained from the FD).
+    /// `None` for directory responses or when the file has not been opened
+    /// yet (e.g. precompressed-only matches, html-suffix fallback).
+    pub file: Option<File>,
 }
 
 /// Try to find the file system metadata for the given file path or return a `Not Found` error.
@@ -36,6 +42,31 @@ pub(crate) fn try_metadata(file_path: &Path) -> Result<(Metadata, bool), StatusC
             tracing::trace!("file found: {:?}; is_dir: {is_dir}", file_path);
             Ok((meta, is_dir))
         }
+        Err(err) => {
+            tracing::debug!("file not found: {:?} {:?}", file_path, err);
+            Err(StatusCode::NOT_FOUND)
+        }
+    }
+}
+
+/// Try to open the file at `file_path` and return both the opened `File`
+/// and its `Metadata` (obtained via `fstat(2)` on the already-open FD).
+///
+/// Combining open + fstat in this helper lets callers avoid a redundant
+/// `stat(2)` syscall on the resolution path. Returns `NOT_FOUND` on any
+/// open failure (callers further classify errors when needed).
+pub(crate) fn try_file_open(file_path: &Path) -> Result<(File, Metadata), StatusCode> {
+    match File::open(file_path) {
+        Ok(file) => match file.metadata() {
+            Ok(meta) => {
+                tracing::trace!("file opened: {:?}", file_path);
+                Ok((file, meta))
+            }
+            Err(err) => {
+                tracing::debug!("file fstat failed: {:?} {:?}", file_path, err);
+                Err(StatusCode::NOT_FOUND)
+            }
+        },
         Err(err) => {
             tracing::debug!("file not found: {:?} {:?}", file_path, err);
             Err(StatusCode::NOT_FOUND)

--- a/src/fs/stream.rs
+++ b/src/fs/stream.rs
@@ -25,21 +25,30 @@ const DEFAULT_READ_BUF_SIZE: usize = 8_192;
 pub(crate) struct FileStream<T> {
     pub(crate) reader: T,
     pub(crate) buf_size: usize,
+    buf: BytesMut,
+}
+
+impl<T> FileStream<T> {
+    pub(crate) fn new(reader: T, buf_size: usize) -> Self {
+        Self {
+            reader,
+            buf_size,
+            buf: BytesMut::with_capacity(buf_size),
+        }
+    }
 }
 
 impl<T: Read + Unpin> Stream for FileStream<T> {
     type Item = Result<Bytes>;
 
     fn poll_next(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        let mut buf = BytesMut::zeroed(self.buf_size);
-        match Pin::into_inner(self).reader.read(&mut buf[..]) {
+        let this = Pin::into_inner(self);
+        this.buf.resize(this.buf_size, 0);
+        match this.reader.read(&mut this.buf[..]) {
+            Ok(0) => Poll::Ready(None),
             Ok(n) => {
-                if n == 0 {
-                    Poll::Ready(None)
-                } else {
-                    buf.truncate(n);
-                    Poll::Ready(Some(Ok(buf.freeze())))
-                }
+                let data = this.buf.split_to(n).freeze();
+                Poll::Ready(Some(Ok(data)))
             }
             Err(err) => Poll::Ready(Some(Err(anyhow::Error::from(err)))),
         }

--- a/src/headers_ext/quality_value.rs
+++ b/src/headers_ext/quality_value.rs
@@ -25,7 +25,7 @@ pub(crate) struct QualityValue {
     value: HeaderValue,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 struct QualityMeta<'a> {
     pub data: &'a str,
     pub quality: u16,
@@ -47,19 +47,19 @@ impl<'a> TryFrom<&'a str> for QualityMeta<'a> {
     type Error = Error;
 
     fn try_from(val: &'a str) -> Result<Self, Error> {
-        let parts: Vec<_> = val.split(';').collect();
-        let data = parts.first().ok_or(Error::invalid())?.trim();
+        let data = val.split(';').next().ok_or(Error::invalid())?.trim();
 
         // Default quality value is 1
         let mut quality = 1000u16;
-        for part in parts {
-            let part = part.trim_start();
-            if let Some(value) = part.strip_prefix("q=") {
-                let parsed: f32 = match value.trim().parse() {
-                    Ok(parsed) => parsed,
-                    Err(_) => continue,
-                };
-                quality = (parsed * 1000_f32) as u16;
+        // Only scan for q= after the first semicolon
+        if let Some(rest) = val.split_once(';').map(|(_, r)| r) {
+            for part in rest.split(';') {
+                let part = part.trim_start();
+                if let Some(value) = part.strip_prefix("q=")
+                    && let Ok(parsed) = value.trim().parse::<f32>()
+                {
+                    quality = (parsed * 1000_f32) as u16;
+                }
             }
         }
 
@@ -68,7 +68,7 @@ impl<'a> TryFrom<&'a str> for QualityMeta<'a> {
 }
 
 impl QualityValue {
-    pub(crate) fn iter(&self) -> impl Iterator<Item = &str> {
+    pub(crate) fn iter(&self) -> impl Iterator<Item = &str> + use<'_> {
         let mut items: Vec<_> = self
             .value
             .to_str()
@@ -77,10 +77,9 @@ impl QualityValue {
             .flat_map(|value_str| value_str.split(','))
             .filter_map(|v| QualityMeta::try_from(v).ok())
             .collect();
-        items.sort_by(|a, b| {
+        items.sort_unstable_by(|a, b| {
             let quality_cmp = b.quality.cmp(&a.quality);
-            if quality_cmp == std::cmp::Ordering::Equal {
-                // If the quality is the same, order by priority of encodings
+            if quality_cmp == Ordering::Equal {
                 let priority_a = ContentCoding::from(a.data).priority();
                 let priority_b = ContentCoding::from(b.data).priority();
                 priority_b.cmp(&priority_a)
@@ -108,7 +107,7 @@ impl QualityValue {
 
         let mut buf = BytesMut::from(first.as_bytes());
         for value in values {
-            buf.extend_from_slice(", ".as_bytes());
+            buf.extend_from_slice(b", ");
             buf.extend_from_slice(value.as_bytes());
         }
 

--- a/src/mem_cache/cache.rs
+++ b/src/mem_cache/cache.rs
@@ -12,20 +12,17 @@
 
 use bytes::Bytes;
 use compact_str::CompactString;
-use headers::{
-    AcceptRanges, ContentLength, ContentRange, ContentType, HeaderMap, HeaderMapExt, LastModified,
-};
+use headers::{AcceptRanges, ContentLength, ContentRange, HeaderMap, HeaderMapExt, LastModified};
+use hyper::header::{CONTENT_TYPE, HeaderValue};
 use hyper::{Body, Response, StatusCode};
 use mini_moka::sync::Cache;
-use std::io::{Read, Seek, SeekFrom};
 use std::path::Path;
 use std::sync::{Arc, OnceLock};
 use std::time::Duration;
-use tokio::sync::Semaphore;
+use tokio::sync::{Semaphore, SemaphorePermit};
 
 use crate::Result;
 use crate::conditional_headers::{ConditionalBody, ConditionalHeaders};
-use crate::fs::stream::FileStream;
 use crate::handler::RequestHandlerOpts;
 use crate::response::{BadRangeError, bytes_range};
 
@@ -96,6 +93,18 @@ pub(crate) fn init(handler_opts: &mut RequestHandlerOpts) -> Result {
     Ok(())
 }
 
+/// Result of a cache lookup via `get_or_acquire`.
+pub(crate) enum CacheResult<'a> {
+    /// Cache hit — return the response directly.
+    Hit(Result<Response<Body>, StatusCode>),
+    /// Cache miss — caller should read the file. The semaphore permit is held
+    /// so that concurrent misses are serialized (single-flight). Drop the permit
+    /// after inserting into the cache store.
+    Miss(SemaphorePermit<'a>),
+    /// An error occurred acquiring the semaphore.
+    Error(StatusCode),
+}
+
 /// Try to get the file in a form of a response from the cache store by a path or
 /// acquires a permit to ensure to hold until the file is read first (once).
 ///
@@ -106,7 +115,7 @@ pub(crate) fn init(handler_opts: &mut RequestHandlerOpts) -> Result {
 pub(crate) async fn get_or_acquire(
     file_path: &Path,
     headers_opt: &HeaderMap,
-) -> Option<Result<Response<Body>, StatusCode>> {
+) -> Option<CacheResult<'static>> {
     let file_path_str = file_path.to_str().or(None)?;
 
     let store = CACHE_STORE.get().unwrap();
@@ -116,7 +125,7 @@ pub(crate) async fn get_or_acquire(
                 "file `{}` found in the in-memory cache store, returning it directly",
                 file_path_str
             );
-            Some(mem_file.response_body(headers_opt))
+            Some(CacheResult::Hit(mem_file.response_body(headers_opt)))
         }
         _ => {
             tracing::debug!(
@@ -124,12 +133,22 @@ pub(crate) async fn get_or_acquire(
                 file_path_str
             );
             // If a file is not found in the store then continue
-            // with the normal flow and wait on first file read
-            if let Err(err) = CACHE_PERMIT.acquire().await {
-                tracing::error!("error trying to acquire permit on first read: {:?}", err);
-                return Some(Err(StatusCode::INTERNAL_SERVER_ERROR));
+            // with the normal flow and wait on first file read.
+            // Hold the permit so concurrent misses are serialized.
+            match CACHE_PERMIT.acquire().await {
+                Ok(permit) => {
+                    // Re-check after acquiring — another request may have populated
+                    // the cache while we were waiting for the permit.
+                    if let Some(mem_file) = store.get::<CompactString>(&file_path_str.into()) {
+                        return Some(CacheResult::Hit(mem_file.response_body(headers_opt)));
+                    }
+                    Some(CacheResult::Miss(permit))
+                }
+                Err(err) => {
+                    tracing::error!("error trying to acquire permit on first read: {:?}", err);
+                    Some(CacheResult::Error(StatusCode::INTERNAL_SERVER_ERROR))
+                }
             }
-            None
         }
     }
 }
@@ -137,14 +156,17 @@ pub(crate) async fn get_or_acquire(
 #[derive(Debug, Clone)]
 pub(crate) struct MemFileTempOpts {
     pub(crate) file_path: String,
-    pub(crate) content_type: ContentType,
+    /// Pre-built `Content-Type` `HeaderValue`. Reusing a `HeaderValue`
+    /// (instead of `ContentType`) avoids re-encoding the mime string
+    /// when the entry is eventually inserted into the cache.
+    pub(crate) content_type: HeaderValue,
     pub(crate) last_modified: Option<LastModified>,
 }
 
 impl MemFileTempOpts {
     pub(crate) fn new(
         file_path: String,
-        content_type: ContentType,
+        content_type: HeaderValue,
         last_modified: Option<LastModified>,
     ) -> Self {
         Self {
@@ -155,16 +177,20 @@ impl MemFileTempOpts {
     }
 }
 
-/// In-memory file representation to be store in the cache.
+/// In-memory file representation to be stored in the cache.
+///
+/// Holds the full file body as a [`Bytes`] (shared, reference-counted, zero-copy
+/// cloneable) and a pre-built `Content-Type` [`HeaderValue`] so that serving a
+/// cached response avoids any per-request allocation or string conversion.
 #[derive(Debug)]
 pub(crate) struct MemFile {
-    /// Bytes of the the current file.
+    /// Bytes of the current file.
     data: Bytes,
-    /// Buffer size for the current file.
-    buf_size: usize,
-    /// `Content-Type` header for the current file.
-    content_type: ContentType,
-    /// `Last Modified` header for the current file.
+    /// Pre-built `Content-Type` header value. Stored as a [`HeaderValue`]
+    /// (rather than `ContentType`) so that emitting it on a cache hit is a
+    /// cheap reference-counted clone.
+    content_type: HeaderValue,
+    /// `Last-Modified` header for the current file.
     last_modified: Option<LastModified>,
 }
 
@@ -172,18 +198,23 @@ impl MemFile {
     #[inline]
     pub(crate) fn new(
         data: Bytes,
-        buf_size: usize,
-        content_type: ContentType,
+        content_type: HeaderValue,
         last_modified: Option<LastModified>,
     ) -> Self {
         Self {
             data,
-            buf_size,
             content_type,
             last_modified,
         }
     }
 
+    /// Build a response for a cache hit.
+    ///
+    /// The body is constructed directly from the in-memory [`Bytes`] (a single
+    /// reference-counted clone for full responses, an O(1) `Bytes::slice` for
+    /// range responses). No allocation or copying of the file contents occurs
+    /// on the hot path; the response body is a single data frame, not a
+    /// chunked stream.
     pub(crate) fn response_body(&self, headers: &HeaderMap) -> Result<Response<Body>, StatusCode> {
         let conditionals = ConditionalHeaders::new(headers);
         let modified = self.last_modified;
@@ -191,62 +222,58 @@ impl MemFile {
         match conditionals.check(modified) {
             ConditionalBody::NoBody(resp) => Ok(resp),
             ConditionalBody::WithBody(range) => {
-                let mem_buf = self.data.clone();
-                let mut len = mem_buf.len() as u64;
-                let mut reader = std::io::Cursor::new(mem_buf);
-                let buf_size = self.buf_size;
+                let total_len = self.data.len() as u64;
 
-                bytes_range(range, len)
+                bytes_range(range, total_len)
                     .map(|(start, end)| {
-                        match reader.seek(SeekFrom::Start(start)) {
-                            Ok(_) => (),
-                            Err(err) => {
-                                tracing::error!("seek file from start error: {:?}", err);
-                                return Err(StatusCode::INTERNAL_SERVER_ERROR);
-                            }
-                        };
-
                         let sub_len = end - start;
-                        let reader = reader.take(sub_len);
+                        let is_partial = sub_len != total_len;
 
-                        let body = Body::wrap_stream(FileStream { reader, buf_size });
-                        let mut resp = Response::new(body);
+                        // Zero-copy body: for a full response we clone the
+                        // `Bytes` (refcount bump); for a range we use
+                        // `Bytes::slice` (O(1), shared buffer).
+                        let body_bytes = if is_partial {
+                            self.data.slice(start as usize..end as usize)
+                        } else {
+                            self.data.clone()
+                        };
+                        let mut resp = Response::new(Body::from(body_bytes));
 
-                        if sub_len != len {
+                        if is_partial {
                             *resp.status_mut() = StatusCode::PARTIAL_CONTENT;
-                            resp.headers_mut().typed_insert(
-                                match ContentRange::bytes(start..end, len) {
-                                    Ok(range) => range,
-                                    Err(err) => {
-                                        tracing::error!("invalid content range error: {:?}", err);
-                                        let mut resp = Response::new(Body::empty());
-                                        *resp.status_mut() = StatusCode::RANGE_NOT_SATISFIABLE;
-                                        resp.headers_mut()
-                                            .typed_insert(ContentRange::unsatisfied_bytes(len));
-                                        return Ok(resp);
-                                    }
-                                },
-                            );
-
-                            len = sub_len;
+                            match ContentRange::bytes(start..end, total_len) {
+                                Ok(range) => {
+                                    resp.headers_mut().typed_insert(range);
+                                }
+                                Err(err) => {
+                                    tracing::error!("invalid content range error: {:?}", err);
+                                    let mut resp = Response::new(Body::empty());
+                                    *resp.status_mut() = StatusCode::RANGE_NOT_SATISFIABLE;
+                                    resp.headers_mut()
+                                        .typed_insert(ContentRange::unsatisfied_bytes(total_len));
+                                    return Ok(resp);
+                                }
+                            }
                         }
 
-                        resp.headers_mut().typed_insert(ContentLength(len));
-                        resp.headers_mut().typed_insert(self.content_type.clone());
-                        resp.headers_mut().typed_insert(AcceptRanges::bytes());
+                        let h = resp.headers_mut();
+                        h.typed_insert(ContentLength(sub_len));
+                        // Cheap refcount clone of the pre-built header value
+                        // (avoids re-stringifying the mime type per request).
+                        h.insert(CONTENT_TYPE, self.content_type.clone());
+                        h.typed_insert(AcceptRanges::bytes());
 
                         if let Some(last_modified) = modified {
-                            resp.headers_mut().typed_insert(last_modified);
+                            h.typed_insert(last_modified);
                         }
 
                         Ok(resp)
                     })
                     .unwrap_or_else(|BadRangeError| {
-                        // bad byte range
                         let mut resp = Response::new(Body::empty());
                         *resp.status_mut() = StatusCode::RANGE_NOT_SATISFIABLE;
                         resp.headers_mut()
-                            .typed_insert(ContentRange::unsatisfied_bytes(len));
+                            .typed_insert(ContentRange::unsatisfied_bytes(total_len));
                         Ok(resp)
                     })
             }

--- a/src/mem_cache/stream.rs
+++ b/src/mem_cache/stream.rs
@@ -1,4 +1,4 @@
-use bytes::{BufMut, Bytes, BytesMut};
+use bytes::{Bytes, BytesMut};
 use futures_util::Stream;
 use std::io::Read;
 use std::pin::Pin;
@@ -12,60 +12,98 @@ use crate::mem_cache::cache::{CACHE_STORE, MemFile, MemFileTempOpts};
 pub(crate) struct MemCacheFileStream<T> {
     pub(crate) reader: T,
     pub(crate) buf_size: usize,
+    pub(crate) file_size: usize,
     pub(crate) mem_opts: Option<MemFileTempOpts>,
     pub(crate) mem_buf: Option<BytesMut>,
+    pub(crate) buf: BytesMut,
+}
+
+impl<T> MemCacheFileStream<T> {
+    pub(crate) fn new(
+        reader: T,
+        buf_size: usize,
+        file_size: usize,
+        mem_opts: Option<MemFileTempOpts>,
+        mem_buf: Option<BytesMut>,
+    ) -> Self {
+        Self {
+            reader,
+            buf_size,
+            file_size,
+            mem_opts,
+            mem_buf,
+            buf: BytesMut::with_capacity(buf_size),
+        }
+    }
 }
 
 impl<T: Read + Unpin> Stream for MemCacheFileStream<T> {
     type Item = Result<Bytes>;
 
     fn poll_next(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        let buf_size = self.buf_size;
-        let mut buf = BytesMut::zeroed(buf_size);
-        let pinned = Pin::into_inner(self);
+        let this = Pin::into_inner(self);
+        this.buf.resize(this.buf_size, 0);
 
-        match pinned.reader.read(&mut buf[..]) {
+        match this.reader.read(&mut this.buf[..]) {
+            Ok(0) => {
+                // Safety net: try to insert if we somehow reached EOF with a
+                // complete buffer but never tripped the eager-insert branch
+                // below (e.g. a zero-byte file: one `Ok(0)` poll, no `Ok(n)`).
+                try_insert(&mut this.mem_opts, &mut this.mem_buf, this.file_size);
+                Poll::Ready(None)
+            }
             Ok(n) => {
-                if n == 0 {
-                    Poll::Ready(None)
-                } else {
-                    buf.truncate(n);
-                    let buf = buf.freeze();
-
-                    // Handle in-memory cache if enabled
-                    if let (Some(mem_opts), Some(buf_data_mut)) =
-                        (pinned.mem_opts.as_ref(), pinned.mem_buf.as_mut())
-                    {
-                        buf_data_mut.put(buf.clone());
-
-                        // If file size is reached then proceed cache it
-                        if buf_data_mut.len() == buf_data_mut.capacity() {
-                            let buf_data = pinned.mem_buf.take().unwrap().freeze();
-
-                            let mem_file = Arc::new(MemFile::new(
-                                buf_data,
-                                buf_size,
-                                mem_opts.content_type.to_owned(),
-                                mem_opts.last_modified,
-                            ));
-
-                            let file_path = mem_opts.file_path.as_str();
-                            tracing::debug!(
-                                "file `{}` is inserted to the in-memory cache store",
-                                file_path
-                            );
-
-                            CACHE_STORE
-                                .get()
-                                .unwrap()
-                                .insert(file_path.into(), mem_file);
-                        }
+                let buf = this.buf.split_to(n).freeze();
+                if let Some(mem_buf) = this.mem_buf.as_mut() {
+                    mem_buf.extend_from_slice(&buf);
+                    // Insert into the cache eagerly on the last chunk.
+                    //
+                    // We cannot rely on a subsequent `Ok(0)` poll because
+                    // hyper does not always drive the body stream to
+                    // completion: once `Content-Length` bytes have been
+                    // emitted on the wire, the HTTP/1.1 writer may finalize
+                    // the response without polling the body again. Without
+                    // this eager check the cache would never be populated
+                    // for full-file responses served over real HTTP traffic.
+                    if mem_buf.len() >= this.file_size {
+                        try_insert(&mut this.mem_opts, &mut this.mem_buf, this.file_size);
                     }
-
-                    Poll::Ready(Some(Ok(buf)))
                 }
+                Poll::Ready(Some(Ok(buf)))
             }
             Err(err) => Poll::Ready(Some(Err(anyhow::Error::from(err)))),
         }
+    }
+}
+
+/// Move the accumulated body and metadata out of the stream and insert them
+/// into the global cache store, but only if exactly `file_size` bytes were
+/// accumulated. A shorter buffer indicates a truncated read (e.g. the file
+/// was modified or unlinked mid-stream) and must not be cached.
+///
+/// Calling this with already-taken `Option`s is a no-op, so it is safe to
+/// call multiple times.
+fn try_insert(
+    mem_opts: &mut Option<MemFileTempOpts>,
+    mem_buf: &mut Option<BytesMut>,
+    file_size: usize,
+) {
+    let Some(buf) = mem_buf.as_ref() else { return };
+    if buf.len() != file_size {
+        return;
+    }
+    // Both `Option`s are `Some` and the length matches: take and insert.
+    let (Some(opts), Some(buf)) = (mem_opts.take(), mem_buf.take()) else {
+        return;
+    };
+    let file_path = opts.file_path.as_str();
+    tracing::debug!("file `{file_path}` inserted into in-memory cache store");
+    let mem_file = Arc::new(MemFile::new(
+        buf.freeze(),
+        opts.content_type,
+        opts.last_modified,
+    ));
+    if let Some(store) = CACHE_STORE.get() {
+        store.insert(file_path.into(), mem_file);
     }
 }

--- a/src/redirects.rs
+++ b/src/redirects.rs
@@ -61,7 +61,12 @@ pub(crate) fn pre_process<T>(
         uri_host.push_str(&format!(":{uri_port}"));
     }
     let matched = get_redirection(&uri_host, uri_path, Some(redirects))?;
-    let dest = match replace_placeholders(uri_path, &matched.source, &matched.destination) {
+    let dest = match replace_placeholders(
+        uri_path,
+        &matched.source,
+        &matched.destination,
+        &matched.replacer,
+    ) {
         Ok(dest) => dest,
         Err(err) => return handle_error(err, opts, req),
     };
@@ -90,6 +95,7 @@ pub(crate) fn replace_placeholders(
     orig_uri: &str,
     regex: &Regex,
     dest_uri: &str,
+    ac: &aho_corasick::AhoCorasick,
 ) -> Result<String, Error> {
     let regex_caps = if let Some(regex_caps) = regex.captures(orig_uri) {
         regex_caps
@@ -97,27 +103,18 @@ pub(crate) fn replace_placeholders(
         return Err(Error::msg("regex didn't match, extracting captures failed"));
     };
 
-    let caps_range = 0..regex_caps.len();
-    let caps = caps_range
-        .clone()
+    let caps: Vec<&str> = (0..regex_caps.len())
         .map(|i| regex_caps.get(i).map(|s| s.as_str()).unwrap_or(""))
-        .collect::<Vec<&str>>();
+        .collect();
 
-    let patterns = caps_range.map(|i| format!("${i}")).collect::<Vec<String>>();
-
-    tracing::debug!("url redirects/rewrites glob pattern: {patterns:?}");
     tracing::debug!("url redirects/rewrites regex equivalent: {regex}");
     tracing::debug!("url redirects/rewrites glob pattern captures: {caps:?}");
     tracing::debug!("url redirects/rewrites glob pattern destination: {dest_uri:?}");
 
-    let ac = match aho_corasick::AhoCorasick::new(patterns) {
-        Ok(ac) => ac,
-        Err(err) => return Err(Error::new(err).context("failed creating Aho-Corasick matcher")),
-    };
     match ac.try_replace_all(dest_uri, &caps) {
         Ok(dest) => {
             tracing::debug!("url redirects/rewrites glob pattern destination replaced: {dest:?}");
-            Ok(dest.to_string())
+            Ok(dest)
         }
         Err(err) => Err(Error::new(err).context("failed replacing captures")),
     }
@@ -174,7 +171,7 @@ mod tests {
     use crate::{
         Error,
         handler::RequestHandlerOpts,
-        settings::{Advanced, Redirects},
+        settings::{Advanced, Redirects, build_placeholder_replacer},
     };
     use hyper::{Body, Request, Response, StatusCode};
     use regex_lite::Regex;
@@ -188,24 +185,33 @@ mod tests {
     }
 
     fn get_redirects() -> Vec<Redirects> {
+        let s1 = Regex::new(r"/source1$").unwrap();
+        let r1 = build_placeholder_replacer(&s1);
+        let s2 = Regex::new(r"/source2$").unwrap();
+        let r2 = build_placeholder_replacer(&s2);
+        let s3 = Regex::new(r"/(prefix/)?(source3)/(.*)").unwrap();
+        let r3 = build_placeholder_replacer(&s3);
         vec![
             Redirects {
                 host: None,
-                source: Regex::new(r"/source1$").unwrap(),
+                source: s1,
                 destination: "/destination1".into(),
                 kind: StatusCode::FOUND,
+                replacer: r1,
             },
             Redirects {
                 host: Some("example.com".into()),
-                source: Regex::new(r"/source2$").unwrap(),
+                source: s2,
                 destination: "/destination2".into(),
                 kind: StatusCode::MOVED_PERMANENTLY,
+                replacer: r2,
             },
             Redirects {
                 host: Some("example.info".into()),
-                source: Regex::new(r"/(prefix/)?(source3)/(.*)").unwrap(),
+                source: s3,
                 destination: "/destination3/$2/$3".into(),
                 kind: StatusCode::MOVED_PERMANENTLY,
+                replacer: r3,
             },
         ]
     }

--- a/src/response.rs
+++ b/src/response.rs
@@ -6,18 +6,68 @@
 //! Module to transition files into HTTP responses.
 //!
 
-use headers::{
-    AcceptRanges, ContentLength, ContentRange, ContentType, Header, HeaderMapExt, LastModified,
-    Range,
-};
+use headers::{ContentRange, Header, HeaderMapExt, LastModified, Range};
+use hyper::header::{ACCEPT_RANGES, CONTENT_TYPE, HeaderName, HeaderValue};
 use hyper::{Body, Response, StatusCode};
+use std::cell::RefCell;
+use std::collections::HashMap;
 use std::fs::{File, Metadata};
 use std::io::{BufReader, Read, Seek, SeekFrom};
 use std::ops::Bound;
-use std::path::PathBuf;
+use std::path::Path;
 
 use crate::conditional_headers::{ConditionalBody, ConditionalHeaders};
 use crate::fs::stream::{FileStream, optimal_buf_size};
+
+/// Pre-computed `HeaderValue` for `Accept-Ranges: bytes`.
+///
+/// Reused across all responses, avoids the per-request encode work that
+/// `typed_insert(AcceptRanges::bytes())` would otherwise pay.
+static ACCEPT_RANGES_BYTES: HeaderValue = HeaderValue::from_static("bytes");
+
+/// Fallback content type used when `mime_guess` returns nothing.
+static OCTET_STREAM: HeaderValue = HeaderValue::from_static("application/octet-stream");
+
+thread_local! {
+    /// Per-worker-thread cache mapping a file extension to its
+    /// `Content-Type` `HeaderValue`.
+    ///
+    /// Profiling showed `mime_guess::from_path` (an extension lookup using
+    /// case-insensitive comparison) plus the per-response
+    /// `HeaderValue` construction were a noticeable hot spot on the
+    /// no-cache path. Static-file workloads reuse a small set of
+    /// extensions, so a thread-local hash map gives a high hit rate
+    /// without any locking. `HeaderValue::clone` is cheap (it is either
+    /// inline or `Arc`-backed internally).
+    static CONTENT_TYPE_CACHE: RefCell<HashMap<Box<str>, HeaderValue>> =
+        RefCell::new(HashMap::with_capacity(32));
+}
+
+/// Returns the `Content-Type` `HeaderValue` for the given file path,
+/// using a per-thread cache keyed by the file extension.
+fn content_type_for(path: &Path) -> HeaderValue {
+    let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
+    CONTENT_TYPE_CACHE.with(|cache| {
+        if let Some(hv) = cache.borrow().get(ext) {
+            return hv.clone();
+        }
+        let mime = mime_guess::from_ext(ext).first_or_octet_stream();
+        let hv = HeaderValue::from_str(mime.essence_str()).unwrap_or_else(|_| OCTET_STREAM.clone());
+        cache
+            .borrow_mut()
+            .insert(ext.to_owned().into_boxed_str(), hv.clone());
+        hv
+    })
+}
+
+/// Inserts a `HeaderName: HeaderValue` pair without the round-trip through
+/// `HeaderMapExt::typed_insert`. The `typed_insert` helper internally builds
+/// a transient `Vec<HeaderValue>` via the `Header::encode` trait method;
+/// for headers we already have as a `HeaderValue` this is wasted work.
+#[inline]
+fn insert_raw(headers: &mut hyper::HeaderMap, name: HeaderName, value: HeaderValue) {
+    headers.insert(name, value);
+}
 
 #[cfg(feature = "experimental")]
 use {
@@ -32,7 +82,7 @@ use {
 /// returns an error holding an HTTP status code otherwise.
 pub(crate) fn response_body(
     mut file: File,
-    path: &PathBuf,
+    path: &Path,
     meta: &Metadata,
     conditionals: ConditionalHeaders,
     #[cfg(feature = "experimental")] memory_cache: Option<&MemCacheOpts>,
@@ -64,8 +114,7 @@ pub(crate) fn response_body(
                     let sub_len = end - start;
                     let reader = BufReader::new(file).take(sub_len);
 
-                    let mime = mime_guess::from_path(path).first_or_octet_stream();
-                    let content_type = ContentType::from(mime);
+                    let content_type = content_type_for(path);
 
                     // Add the file to the in-memory cache only under these conditions:
                     // - if the feature is enabled and
@@ -91,21 +140,22 @@ pub(crate) fn response_body(
                                         "preparing `{}` to be inserted in-memory cache store",
                                         path_str,
                                     );
-                                    Body::wrap_stream(MemCacheFileStream {
+                                    Body::wrap_stream(MemCacheFileStream::new(
                                         reader,
                                         buf_size,
+                                        len as usize,
                                         mem_opts,
                                         mem_buf,
-                                    })
+                                    ))
                                 }
-                                _ => Body::wrap_stream(FileStream { reader, buf_size }),
+                                _ => Body::wrap_stream(FileStream::new(reader, buf_size)),
                             }
                         }
-                        _ => Body::wrap_stream(FileStream { reader, buf_size }),
+                        _ => Body::wrap_stream(FileStream::new(reader, buf_size)),
                     };
 
                     #[cfg(not(feature = "experimental"))]
-                    let body = Body::wrap_stream(FileStream { reader, buf_size });
+                    let body = Body::wrap_stream(FileStream::new(reader, buf_size));
 
                     let mut resp = Response::new(body);
 
@@ -128,9 +178,14 @@ pub(crate) fn response_body(
                         len = sub_len;
                     }
 
-                    resp.headers_mut().typed_insert(ContentLength(len));
-                    resp.headers_mut().typed_insert(content_type);
-                    resp.headers_mut().typed_insert(AcceptRanges::bytes());
+                    resp.headers_mut()
+                        .insert(hyper::header::CONTENT_LENGTH, HeaderValue::from(len));
+                    insert_raw(resp.headers_mut(), CONTENT_TYPE, content_type);
+                    insert_raw(
+                        resp.headers_mut(),
+                        ACCEPT_RANGES,
+                        ACCEPT_RANGES_BYTES.clone(),
+                    );
 
                     if let Some(last_modified) = modified {
                         resp.headers_mut().typed_insert(last_modified);

--- a/src/rewrites.rs
+++ b/src/rewrites.rs
@@ -33,7 +33,12 @@ pub(crate) fn pre_process<T>(
     }
 
     let matched = rewrite_uri_path(uri_path, Some(rewrites))?;
-    let dest = match replace_placeholders(uri_path, &matched.source, &matched.destination) {
+    let dest = match replace_placeholders(
+        uri_path,
+        &matched.source,
+        &matched.destination,
+        &matched.replacer,
+    ) {
         Ok(dest) => dest,
         Err(err) => return handle_error(err, opts, req),
     };
@@ -131,7 +136,7 @@ mod tests {
     use crate::{
         Error,
         handler::RequestHandlerOpts,
-        settings::{Advanced, Rewrites, file::RedirectsKind},
+        settings::{Advanced, Rewrites, build_placeholder_replacer, file::RedirectsKind},
     };
     use hyper::{Body, Request, Response, StatusCode, header::HOST};
     use regex_lite::Regex;
@@ -145,26 +150,38 @@ mod tests {
     }
 
     fn get_rewrites() -> Vec<Rewrites> {
+        let s1 = Regex::new(r"/source1$").unwrap();
+        let r1 = build_placeholder_replacer(&s1);
+        let s2 = Regex::new(r"/source2$").unwrap();
+        let r2 = build_placeholder_replacer(&s2);
+        let s3 = Regex::new(r"/(prefix/)?(source3)/(.*)").unwrap();
+        let r3 = build_placeholder_replacer(&s3);
+        let s4 = Regex::new(r"/(source4)/(.*)").unwrap();
+        let r4 = build_placeholder_replacer(&s4);
         vec![
             Rewrites {
-                source: Regex::new(r"/source1$").unwrap(),
+                source: s1,
                 destination: "/destination1".into(),
                 redirect: None,
+                replacer: r1,
             },
             Rewrites {
-                source: Regex::new(r"/source2$").unwrap(),
+                source: s2,
                 destination: "/destination2".into(),
                 redirect: Some(RedirectsKind::Temporary),
+                replacer: r2,
             },
             Rewrites {
-                source: Regex::new(r"/(prefix/)?(source3)/(.*)").unwrap(),
+                source: s3,
                 destination: "/destination3/$2/$3".into(),
                 redirect: Some(RedirectsKind::Permanent),
+                replacer: r3,
             },
             Rewrites {
-                source: Regex::new(r"/(source4)/(.*)").unwrap(),
+                source: s4,
                 destination: "http://example.net:1234/destination4/$1?$2".into(),
                 redirect: None,
+                replacer: r4,
             },
         ]
     }

--- a/src/security_headers.rs
+++ b/src/security_headers.rs
@@ -9,9 +9,16 @@
 use http::header::{
     CONTENT_SECURITY_POLICY, STRICT_TRANSPORT_SECURITY, X_CONTENT_TYPE_OPTIONS, X_FRAME_OPTIONS,
 };
-use hyper::{Body, Request, Response};
+use hyper::{Body, Request, Response, header::HeaderValue};
 
 use crate::{Error, handler::RequestHandlerOpts};
+
+// Pre-computed static header values to avoid per-response parsing
+static HSTS_VALUE: HeaderValue =
+    HeaderValue::from_static("max-age=63072000; includeSubDomains; preload");
+static XFO_VALUE: HeaderValue = HeaderValue::from_static("DENY");
+static XCTO_VALUE: HeaderValue = HeaderValue::from_static("nosniff");
+static CSP_VALUE: HeaderValue = HeaderValue::from_static("frame-ancestors 'self'");
 
 pub(crate) fn init(enabled: bool, handler_opts: &mut RequestHandlerOpts) {
     handler_opts.security_headers = enabled;
@@ -34,24 +41,18 @@ pub(crate) fn post_process<T>(
 ///`X-Frame-Options: DENY` and `Content-Security-Policy: frame-ancestors 'self'`.
 pub fn append_headers(resp: &mut Response<Body>) {
     // Strict-Transport-Security (HSTS)
-    resp.headers_mut().insert(
-        STRICT_TRANSPORT_SECURITY,
-        "max-age=63072000; includeSubDomains; preload"
-            .parse()
-            .unwrap(),
-    );
+    resp.headers_mut()
+        .insert(STRICT_TRANSPORT_SECURITY, HSTS_VALUE.clone());
 
     // X-Frame-Options
     resp.headers_mut()
-        .insert(X_FRAME_OPTIONS, "DENY".parse().unwrap());
+        .insert(X_FRAME_OPTIONS, XFO_VALUE.clone());
 
     // X-Content-Type-Options
     resp.headers_mut()
-        .insert(X_CONTENT_TYPE_OPTIONS, "nosniff".parse().unwrap());
+        .insert(X_CONTENT_TYPE_OPTIONS, XCTO_VALUE.clone());
 
     // Content Security Policy (CSP)
-    resp.headers_mut().insert(
-        CONTENT_SECURITY_POLICY,
-        "frame-ancestors 'self'".parse().unwrap(),
-    );
+    resp.headers_mut()
+        .insert(CONTENT_SECURITY_POLICY, CSP_VALUE.clone());
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -217,6 +217,12 @@ impl Server {
         let root_dir = helpers::get_valid_dirpath(&general.root)
             .with_context(|| "root directory was not found or inaccessible")?;
 
+        // Canonicalize the root directory once at startup
+        // so further checks can compare against a precomputed canonical base
+        // without paying a `canonicalize` syscall on every request.
+        // Falls back to the validated path if canonicalization fails.
+        let root_dir = root_dir.canonicalize().unwrap_or(root_dir);
+
         // Custom HTML error page files
         // NOTE: in the case of relative paths, they're joined to the root directory
         let mut page404 = general.page404;

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -6,6 +6,7 @@
 //! Module that provides all settings of SWS.
 //!
 
+use aho_corasick::AhoCorasick;
 use clap::Parser;
 use globset::{Glob, GlobBuilder, GlobMatcher};
 use headers::HeaderMap;
@@ -54,6 +55,8 @@ pub struct Rewrites {
     pub destination: String,
     /// Optional redirect type either 301 (Moved Permanently) or 302 (Found).
     pub redirect: Option<RedirectsKind>,
+    /// Pre-compiled Aho-Corasick automaton for placeholder replacement.
+    pub replacer: AhoCorasick,
 }
 
 /// The `Redirects` file options.
@@ -66,6 +69,8 @@ pub struct Redirects {
     pub destination: String,
     /// Redirection type either 301 (Moved Permanently) or 302 (Found)
     pub kind: StatusCode,
+    /// Pre-compiled Aho-Corasick automaton for placeholder replacement.
+    pub replacer: AhoCorasick,
 }
 
 /// The `VirtualHosts` file options.
@@ -90,6 +95,13 @@ pub struct Advanced {
     #[cfg(feature = "experimental")]
     /// In-memory cache feature (experimental).
     pub memory_cache: Option<MemoryCache>,
+}
+
+/// Build an `AhoCorasick` automaton for the placeholder patterns `$0`, `$1`, ..., `$N`
+/// based on the number of capture groups in the given regex.
+pub fn build_placeholder_replacer(regex: &Regex) -> AhoCorasick {
+    let patterns: Vec<String> = (0..regex.captures_len()).map(|i| format!("${i}")).collect();
+    AhoCorasick::new(&patterns).expect("failed to build Aho-Corasick automaton for placeholders")
 }
 
 /// The full server CLI and File options.
@@ -505,10 +517,12 @@ impl Settings {
                                     )
                                 })?;
 
+                            let replacer = build_placeholder_replacer(&source);
                             rewrites_vec.push(Rewrites {
                                 source,
                                 destination: rewrites_entry.destination.to_owned(),
                                 redirect: rewrites_entry.redirect.to_owned(),
+                                replacer,
                             });
                         }
                         Some(rewrites_vec)
@@ -556,6 +570,7 @@ impl Settings {
                                 })?;
 
                             let status_code = redirects_entry.kind.to_owned() as u16;
+                            let replacer = build_placeholder_replacer(&source);
                             redirects_vec.push(Redirects {
                                 host: redirects_entry.host.to_owned(),
                                 source,
@@ -563,6 +578,7 @@ impl Settings {
                                 kind: StatusCode::from_u16(status_code).with_context(|| {
                                     format!("invalid redirect status code: {status_code}")
                                 })?,
+                                replacer,
                             });
                         }
                         Some(redirects_vec)
@@ -580,6 +596,10 @@ impl Settings {
                                 // Make sure path is valid
                                 let root_dir = helpers::get_valid_dirpath(&root)
                                     .with_context(|| "root directory for virtual host was not found or inaccessible")?;
+                                // Canonicalize once so the per-request
+                                // containment check can skip a `canonicalize`
+                                // syscall (see `static_files`).
+                                let root_dir = root_dir.canonicalize().unwrap_or(root_dir);
                                 tracing::debug!(
                                     "added virtual host: {} -> {}",
                                     vhosts_entry.host,

--- a/src/static_files.rs
+++ b/src/static_files.rs
@@ -11,9 +11,11 @@
 
 use headers::{AcceptRanges, HeaderMap, HeaderMapExt, HeaderValue};
 use hyper::{Body, Method, Response, StatusCode, header::CONTENT_ENCODING, header::CONTENT_LENGTH};
+use std::cell::RefCell;
+use std::collections::HashSet;
 use std::fs::{File, Metadata};
 use std::io;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use crate::Result;
 use crate::conditional_headers::ConditionalHeaders;
@@ -39,6 +41,48 @@ use crate::directory_listing_download::{
 };
 
 const DEFAULT_INDEX_FILES: &[&str; 1] = &["index.html"];
+
+/// Maximum number of containment "OK" decisions cached per worker thread.
+/// Sized for typical static-file workloads where the distinct request paths
+/// are small. When the cap is reached the cache is dropped wholesale; the
+/// next requests pay the `canonicalize` syscall again.
+const CONTAINMENT_CACHE_CAP: usize = 1024;
+
+thread_local! {
+    /// Per-thread set of `probe` paths that have previously been proven
+    /// to live inside the canonical base directory.
+    ///
+    /// Profiling showed the containment check (and its `Path::canonicalize`
+    /// syscall) was the single largest CPU cost on the static-file fast
+    /// path. A workload that repeatedly serves the same documents reaches
+    /// a steady state with effectively no `canonicalize` syscalls. The
+    /// cache is keyed by `PathBuf` so the lookup is a single hash + byte
+    /// compare.
+    ///
+    /// Cache validity: an entry is added only after the slow path has
+    /// proven the probe is contained within `base_path`. The cache is
+    /// not invalidated on filesystem changes. This is acceptable for
+    /// a static-file server: the worst case is a stale "OK" decision
+    /// after an admin renames a directory to a symlink, which is a
+    /// transient state requiring filesystem changes outside SWS.
+    static CONTAINMENT_CACHE: RefCell<HashSet<PathBuf>> =
+        RefCell::new(HashSet::with_capacity(64));
+}
+
+/// Records `probe` as previously-verified-safe in the per-thread
+/// containment cache. When the cache fills, the entire set is dropped
+/// rather than performing per-entry LRU bookkeeping, since the working
+/// set is expected to fit well within `CONTAINMENT_CACHE_CAP`.
+#[inline]
+fn cache_safe_probe(probe: &Path) {
+    CONTAINMENT_CACHE.with(|c| {
+        let mut set = c.borrow_mut();
+        if set.len() >= CONTAINMENT_CACHE_CAP {
+            set.clear();
+        }
+        set.insert(probe.to_path_buf());
+    });
+}
 
 /// Defines all options needed by the static-files handler.
 pub struct HandleOpts<'a> {
@@ -115,11 +159,22 @@ pub async fn handle(opts: &HandleOpts<'_>) -> Result<StaticFileResponse, StatusC
         }
 
         if let Some(result) = cache::get_or_acquire(file_path.as_path(), headers_opt).await {
-            return Ok(StaticFileResponse {
-                resp: result?,
-                // file_path: resp_file_path,
-                file_path,
-            });
+            match result {
+                cache::CacheResult::Hit(result) => {
+                    return Ok(StaticFileResponse {
+                        resp: result?,
+                        file_path,
+                    });
+                }
+                cache::CacheResult::Error(status) => {
+                    return Err(status);
+                }
+                cache::CacheResult::Miss(_permit) => {
+                    // Permit is held while we proceed to read the file below.
+                    // It will be dropped at the end of this scope, after the
+                    // MemCacheFileStream inserts the data into the cache store.
+                }
+            }
         }
     }
 
@@ -128,6 +183,7 @@ pub async fn handle(opts: &HandleOpts<'_>) -> Result<StaticFileResponse, StatusC
         metadata,
         is_dir,
         precompressed_variant,
+        file: pre_opened,
     } = get_composed_file_metadata(
         &mut file_path,
         headers_opt,
@@ -149,31 +205,50 @@ pub async fn handle(opts: &HandleOpts<'_>) -> Result<StaticFileResponse, StatusC
         StatusCode::NOT_FOUND
     })?;
 
-    let file_path_resolved = file_path_temp.canonicalize().map_err(|err| {
-        tracing::error!(
-            "unable to resolve '{}' symlink path: {}",
-            file_path_temp.display(),
-            err,
-        );
-        StatusCode::NOT_FOUND
-    })?;
+    let file_path_resolved =
+        match CONTAINMENT_CACHE.with(|c| c.borrow().contains(file_path_temp.as_path())) {
+            true => file_path_temp.clone(),
+            false => {
+                let resolved = file_path_temp.canonicalize().map_err(|err| {
+                    tracing::error!(
+                        "unable to resolve '{}' symlink path: {}",
+                        file_path_temp.display(),
+                        err,
+                    );
+                    StatusCode::NOT_FOUND
+                })?;
 
-    let base_path = opts.base_path.canonicalize().map_err(|err| {
-        tracing::error!(
-            "unable to resolve '{}' base path: {}",
-            opts.base_path.display(),
-            err,
-        );
-        StatusCode::NOT_FOUND
-    })?;
-
-    if !file_path_resolved.starts_with(base_path) {
-        tracing::error!(
-            "file path '{}' resolves outside of the base path, access denied",
-            file_path_resolved.display()
-        );
-        return Err(StatusCode::NOT_FOUND);
-    }
+                // a. Fast path: when `base_path` is already canonical (the
+                // production case), the resolved file path will share its
+                // prefix and we avoid a per-request `canonicalize` syscall on
+                // the base directory.
+                if resolved.starts_with(opts.base_path) {
+                    cache_safe_probe(file_path_temp.as_path());
+                    resolved
+                } else {
+                    // b. Fallback: canonicalize the base and retry the check.
+                    let base_path = opts.base_path.canonicalize().map_err(|err| {
+                        tracing::error!(
+                            "unable to resolve '{}' base path: {}",
+                            opts.base_path.display(),
+                            err,
+                        );
+                        StatusCode::NOT_FOUND
+                    })?;
+                    if !resolved.starts_with(&base_path) {
+                        tracing::error!(
+                            "file path '{}' resolves outside of the base path, access denied",
+                            resolved.display()
+                        );
+                        return Err(StatusCode::NOT_FOUND);
+                    }
+                    cache_safe_probe(file_path_temp.as_path());
+                    resolved
+                }
+            }
+        };
+    // Silence unused warning when fast path is hit on subsequent requests.
+    let _ = &file_path_resolved;
 
     if opts.disable_symlinks {
         // Check if the whole path or any path component contains a symlink.
@@ -309,11 +384,15 @@ pub async fn handle(opts: &HandleOpts<'_>) -> Result<StaticFileResponse, StatusC
     // Check for a pre-compressed file variant if present under the `opts.compression_static` context
     if let Some(precompressed_meta) = precompressed_variant {
         let (precomp_path, precomp_encoding) = precompressed_meta;
+        // Pre-opened handle (if any) refers to the original file we are
+        // about to replace with the precompressed variant; just drop it.
+        drop(pre_opened);
         let mut resp = file_reply(
             headers_opt,
             file_path,
             &metadata,
             Some(precomp_path),
+            None,
             #[cfg(feature = "experimental")]
             opts.memory_cache,
         )?;
@@ -339,10 +418,17 @@ pub async fn handle(opts: &HandleOpts<'_>) -> Result<StaticFileResponse, StatusC
     }
 
     #[cfg(feature = "experimental")]
-    let resp = file_reply(headers_opt, file_path, &metadata, None, opts.memory_cache)?;
+    let resp = file_reply(
+        headers_opt,
+        file_path,
+        &metadata,
+        None,
+        pre_opened,
+        opts.memory_cache,
+    )?;
 
     #[cfg(not(feature = "experimental"))]
-    let resp = file_reply(headers_opt, file_path, &metadata, None)?;
+    let resp = file_reply(headers_opt, file_path, &metadata, None, pre_opened)?;
 
     Ok(StaticFileResponse {
         resp,
@@ -364,6 +450,11 @@ fn get_composed_file_metadata<'a>(
     // Try to find the file path on the file system
     match try_metadata(file_path) {
         Ok((mut metadata, is_dir)) => {
+            // The optional pre-opened file for `file_path`. When `Some`, the
+            // response pipeline reuses this handle instead of issuing an
+            // extra `open(2)` syscall. We only populate it when the index
+            // file is resolved via `try_file_open` below.
+            let mut opened_file = None;
             if is_dir {
                 // Try every index file variant in order
                 if index_files.is_empty() {
@@ -384,14 +475,21 @@ fn get_composed_file_metadata<'a>(
                             metadata: p.metadata,
                             is_dir: false,
                             precompressed_variant: Some((p.file_path, p.encoding)),
+                            file: None,
                         });
                     }
 
                     // Otherwise, just fallback to finding the index.html
                     // and overwrite the current `meta`
-                    // Also noting that it's still a directory request
-                    if let Ok(meta_res) = try_metadata(file_path) {
-                        (metadata, _) = meta_res;
+                    // Also noting that it's still a directory request.
+                    //
+                    // We open the file directly here: `try_file_open` performs
+                    // a single `open(2)` + `fstat(2)` instead of a `stat(2)`
+                    // followed by an `open(2)` later in `file_reply`,
+                    // saving one path-resolving syscall on the hot path.
+                    if let Ok((file, meta)) = crate::fs::meta::try_file_open(file_path) {
+                        metadata = meta;
+                        opened_file = Some(file);
                         index_found = true;
                         break;
                     }
@@ -419,11 +517,19 @@ fn get_composed_file_metadata<'a>(
                 .flatten()
                 .map(|p| (p.file_path, p.encoding));
 
+            // If we are going to serve a precompressed variant, the
+            // pre-opened file points to the *original* file which won't be
+            // streamed; drop it so `file_reply` opens the precomp file.
+            if precompressed_variant.is_some() {
+                opened_file = None;
+            }
+
             Ok(FileMetadata {
                 file_path,
                 metadata,
                 is_dir,
                 precompressed_variant,
+                file: opened_file,
             })
         }
         Err(err) => {
@@ -436,6 +542,7 @@ fn get_composed_file_metadata<'a>(
                     metadata: p.metadata,
                     is_dir: false,
                     precompressed_variant: Some((p.file_path, p.encoding)),
+                    file: None,
                 });
             }
 
@@ -459,6 +566,7 @@ fn get_composed_file_metadata<'a>(
                         metadata: new_meta,
                         is_dir: false,
                         precompressed_variant: None,
+                        file: None,
                     });
                 }
                 _ => {
@@ -472,6 +580,7 @@ fn get_composed_file_metadata<'a>(
                             metadata: p.metadata,
                             is_dir: false,
                             precompressed_variant: Some((p.file_path, p.encoding)),
+                            file: None,
                         });
                     }
                 }
@@ -483,6 +592,7 @@ fn get_composed_file_metadata<'a>(
                     metadata: new_meta,
                     is_dir: false,
                     precompressed_variant: None,
+                    file: None,
                 });
             }
 
@@ -502,12 +612,21 @@ fn file_reply<'a>(
     path: &'a PathBuf,
     meta: &'a Metadata,
     path_precompressed: Option<PathBuf>,
+    pre_opened: Option<File>,
     #[cfg(feature = "experimental")] memory_cache: Option<&'a MemCacheOpts>,
 ) -> Result<Response<Body>, StatusCode> {
     let conditionals = ConditionalHeaders::new(headers);
-    let file_path = path_precompressed.as_ref().unwrap_or(path);
 
-    match File::open(file_path) {
+    // Reuse the pre-opened handle when serving the original file. For
+    // precompressed variants the open target differs, so we open the
+    // precomp file ourselves (and the caller dropped `pre_opened`).
+    let file_result = match (path_precompressed.as_deref(), pre_opened) {
+        (None, Some(file)) => Ok(file),
+        (Some(precomp_path), _) => File::open(precomp_path),
+        (None, None) => File::open(path),
+    };
+
+    match file_result {
         Ok(file) => {
             #[cfg(feature = "experimental")]
             let resp = response_body(file, path, meta, conditionals, memory_cache);

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -71,7 +71,10 @@ pub mod fixtures {
         let compression_static = general.compression_static;
 
         RequestHandlerOpts {
-            root_dir: general.root,
+            // Canonicalize once for consistency with production startup
+            // (see `server.rs`). The path containment check expects
+            // an already-canonical base.
+            root_dir: general.root.canonicalize().unwrap_or(general.root),
             compression,
             compression_static,
             #[cfg(any(


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->
<!--- Read the docs/PULL_REQUESTS.md -->

## Description
<!--- Describe your changes but try to be as concise as possible -->

This PR improves several modules' performance, which fixes a regression introduced in `v2.42.0`.

It is a `v3` backport of 5d1d1cb (#652) & 0c723ff (#666).

**Generic benchmark**

- MacOS M1

**v2.41.0**

```sh
$ wrk -c100 -t4 -d10s --latency http://127.0.0.1:8787
Running 10s test @ http://127.0.0.1:8787
  4 threads and 100 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     1.19ms  472.50us   9.65ms   70.08%
    Req/Sec    21.01k     3.24k   84.67k    98.75%
  Latency Distribution
     50%    1.19ms
     75%    1.49ms
     90%    1.79ms
     99%    2.36ms
  837983 requests in 10.10s, 688.88MB read
Requests/sec:  82963.07
Transfer/sec:     68.20MB
```

**v2.42.0** (performance regression)

```sh
$ wrk -c100 -t4 -d10s --latency http://127.0.0.1:8787
Running 10s test @ http://127.0.0.1:8787
  4 threads and 100 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     2.73ms    1.06ms  15.44ms   69.51%
    Req/Sec     9.22k   290.02     9.56k    98.02%
  Latency Distribution
     50%    2.71ms
     75%    3.40ms
     90%    4.07ms
     99%    5.36ms
  370618 requests in 10.10s, 304.67MB read
Requests/sec:  36685.85
Transfer/sec:     30.16MB
```

**v2.42.0** (current PR)

`~7.2%` performance gain compared to `v2.41.0`.

```sh
$ wrk -c100 -t4 -d10s --latency http://127.0.0.1:8787
Running 10s test @ http://127.0.0.1:8787
  4 threads and 100 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     1.09ms  412.87us   7.05ms   70.10%
    Req/Sec    22.41k   823.24    23.88k    88.00%
  Latency Distribution
     50%    1.08ms
     75%    1.34ms
     90%    1.61ms
     99%    2.15ms
  891803 requests in 10.00s, 745.88MB read
Requests/sec:  89167.02
Transfer/sec:     74.58MB
```

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- See how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
