### PR TITLE
Improve directory listing performance (backport)

### DIFF
--- a/src/directory_listing/autoindex/html.rs
+++ b/src/directory_listing/autoindex/html.rs
@@ -7,7 +7,7 @@ use percent_encoding::percent_decode_str;
 
 use crate::directory_listing::file::{DATETIME_FORMAT_LOCAL, FileEntry};
 use crate::directory_listing::sort::sort_file_entries;
-use crate::directory_listing::style::STYLES;
+use crate::directory_listing::style::STYLES_MIN;
 
 #[cfg(feature = "directory-listing-download")]
 use crate::directory_listing_download::{DOWNLOAD_PARAM_KEY, DirDownloadFmt};
@@ -38,7 +38,7 @@ pub(crate) fn html_auto_index<'a>(
     #[cfg(not(feature = "directory-listing-download"))]
     let download_directory_elem = html! {};
 
-    let styles = STYLES.replace("\n", "").replace("  ", "");
+    let styles: &str = STYLES_MIN.as_str();
     html! {
         (DOCTYPE)
         html {
@@ -105,12 +105,16 @@ pub(crate) fn html_auto_index<'a>(
                                     }
                                 }
                                 td {
-                                    (entry.mtime.map_or("-".to_owned(), |local_dt| {
-                                        local_dt.format(DATETIME_FORMAT_LOCAL).to_string()
-                                    }))
+                                    @match entry.mtime {
+                                        Some(local_dt) => (local_dt.format(DATETIME_FORMAT_LOCAL)),
+                                        None => "-",
+                                    }
                                 }
                                 td align="right" {
-                                    (entry.size.map(format_file_size).unwrap_or("-".into()))
+                                    @match entry.size {
+                                        Some(s) => (FileSize(s)),
+                                        None => "-",
+                                    }
                                 }
                             }
                         }
@@ -127,31 +131,49 @@ pub(crate) fn html_auto_index<'a>(
     }.into()
 }
 
-/// Formats the file size in bytes to a human-readable string
-fn format_file_size(size: u64) -> String {
-    const UNITS: [&str; 6] = ["B", "KiB", "MiB", "GiB", "TiB", "PiB"];
-    let mut size_tmp = size;
+/// `Display` wrapper that writes a human-readable file size directly into the
+/// output buffer, avoiding the per-row `String` allocation that `format!` did.
+pub(crate) struct FileSize(pub u64);
 
-    if size_tmp < 1024 {
-        // return the size with Byte
-        return format!("{} {}", size_tmp, UNITS[0]);
-    }
+impl std::fmt::Display for FileSize {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        const UNITS: [&str; 6] = ["B", "KiB", "MiB", "GiB", "TiB", "PiB"];
+        let mut size_tmp = self.0;
 
-    for unit in &UNITS[1..UNITS.len() - 1] {
-        if size_tmp < 1024 * 1024 {
-            // return the size divided by 1024 with the unit
-            return format!("{:.2} {}", size_tmp as f64 / 1024.0, unit);
+        if size_tmp < 1024 {
+            return write!(f, "{} {}", size_tmp, UNITS[0]);
         }
-        size_tmp >>= 10;
-    }
 
-    // if size is too large, return the largest unit
-    format!("{:.2} {}", size_tmp as f64 / 1024.0, UNITS[UNITS.len() - 1])
+        for unit in &UNITS[1..UNITS.len() - 1] {
+            if size_tmp < 1024 * 1024 {
+                return write!(f, "{:.2} {}", size_tmp as f64 / 1024.0, unit);
+            }
+            size_tmp >>= 10;
+        }
+
+        write!(
+            f,
+            "{:.2} {}",
+            size_tmp as f64 / 1024.0,
+            UNITS[UNITS.len() - 1]
+        )
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::format_file_size;
+    use super::FileSize;
+
+    /// Formats the file size in bytes to a human-readable string.
+    fn format_file_size(size: u64) -> String {
+        FileSize(size).to_string()
+    }
+
+    #[test]
+    fn handle_zero() {
+        let size = 0;
+        assert_eq!("0 B", format_file_size(size))
+    }
 
     #[test]
     fn handle_byte() {

--- a/src/directory_listing/dir.rs
+++ b/src/directory_listing/dir.rs
@@ -84,8 +84,13 @@ pub(crate) struct DirEntryOpts<'a> {
 pub(crate) fn read_dir_entries(mut opt: DirEntryOpts<'_>) -> Result<Response<Body>> {
     let mut dirs_count: usize = 0;
     let mut files_count: usize = 0;
-    let mut file_entries: Vec<FileEntry> = vec![];
-    let root_path_abs = opt.root_path.canonicalize()?;
+    // The root directory is canonicalized once at startup (see
+    // `server.rs`). To avoid an extra `canonicalize()` syscall per
+    // request, we resolve the absolute form lazily — only when a symlink
+    // entry is actually encountered (the uncommon case).
+    let mut root_path_abs: Option<std::path::PathBuf> = None;
+    let (entries_hint, _) = opt.dir_reader.size_hint();
+    let mut file_entries: Vec<FileEntry> = Vec::with_capacity(entries_hint);
 
     for dir_entry in opt.dir_reader {
         let dir_entry = dir_entry.with_context(|| "unable to read directory entry")?;
@@ -129,7 +134,11 @@ pub(crate) fn read_dir_entries(mut opt: DirEntryOpts<'_>) -> Result<Response<Bod
                     continue;
                 }
             };
-            if !symlink_path.starts_with(&root_path_abs) {
+            if !symlink_path.starts_with(root_path_abs.get_or_insert_with(|| {
+                opt.root_path
+                    .canonicalize()
+                    .unwrap_or_else(|_| opt.root_path.to_path_buf())
+            })) {
                 tracing::warn!(
                     "unable to follow symlink {}, access denied",
                     symlink_path.display()
@@ -196,15 +205,14 @@ pub(crate) fn read_dir_entries(mut opt: DirEntryOpts<'_>) -> Result<Response<Bod
 
     // Check the query request uri for a sorting type. E.g https://blah/?sort=5
     if let Some(q) = opt.uri_query {
-        let mut parts = form_urlencoded::parse(q.as_bytes());
-        if parts.count() > 0 {
-            // NOTE: we just pick up the first value (pair)
-            if let Some(code) = parts
-                .find(|(key, _)| key == "sort" && !key.is_empty())
-                .and_then(|(_, value)| value.trim().parse::<u8>().ok())
-            {
-                opt.order_code = code;
-            }
+        // NOTE: we just pick up the first `sort` pair.
+        // Avoid calling `.count()` (which consumes the iterator) and then
+        // re-parsing the query string a second time.
+        if let Some(code) = form_urlencoded::parse(q.as_bytes())
+            .find(|(key, _)| key == "sort")
+            .and_then(|(_, value)| value.trim().parse::<u8>().ok())
+        {
+            opt.order_code = code;
         }
     }
 

--- a/src/directory_listing/style.rs
+++ b/src/directory_listing/style.rs
@@ -3,6 +3,16 @@
 // See https://static-web-server.net/ for more information
 // Copyright (C) 2019-present Jose Quintana <joseluisq.net>
 
+use std::sync::LazyLock;
+
+/// Pre-minified version of `STYLES`, computed once.
+///
+/// The directory listing HTML is rendered on every request, so removing
+/// the two per-request `String::replace` passes here avoids a CSS-sized
+/// allocation and a pair of full string scans per response.
+pub(crate) static STYLES_MIN: LazyLock<String> =
+    LazyLock::new(|| STYLES.replace('\n', "").replace("  ", ""));
+
 pub(crate) const STYLES: &str = r#"
 :after, :before { box-sizing: border-box; }
 html {


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->
<!--- Read the docs/PULL_REQUESTS.md -->

## Description
<!--- Describe your changes but try to be as concise as possible -->

This PR improves the performance of the directory listing by saving 1 syscall and avoiding a few string allocations.

It is a v3 backport from https://github.com/static-web-server/static-web-server/pull/667.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- See how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
