### PR TITLE
File logging support via `--log-file` option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2488,12 +2488,14 @@ dependencies = [
  "shadow-rs",
  "signal-hook",
  "signal-hook-tokio",
+ "tempfile",
  "tokio",
  "tokio-metrics-collector",
  "tokio-rustls",
  "tokio-util",
  "toml",
  "tracing",
+ "tracing-appender",
  "tracing-subscriber",
  "windows-service",
 ]
@@ -2515,6 +2517,12 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
 
 [[package]]
 name = "syn"
@@ -2783,6 +2791,19 @@ checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
+dependencies = [
+ "crossbeam-channel",
+ "symlink",
+ "thiserror 2.0.18",
+ "time",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,6 +116,7 @@ tokio-rustls = { version = "0.26", optional = true, default-features = false }
 tokio-util = { version = "0.7", default-features = false, features = ["io", "compat"] }
 toml = "0.9"
 tracing = { version = "0.1", default-features = false, features = ["std"] }
+tracing-appender = { version = "0.2", default-features = false }
 tracing-subscriber = { version = "0.3", default-features = false, features = ["smallvec", "registry", "parking_lot", "fmt", "ansi", "json", "tracing-log", "local-time"] }
 
 [target.'cfg(all(target_env = "musl", target_pointer_width = "64"))'.dependencies]
@@ -138,8 +139,8 @@ http-body-util = "0.1"
 tokio-rustls = { version = "0.26", default-features = false }
 rustls-pki-types = "1.13"
 rustls-pemfile = "2"
-# Property-based testing for the path-sanitisation security invariants.
 proptest = { version = "1.5", default-features = false, features = ["std"] }
+tempfile = "3"
 
 [build-dependencies]
 shadow-rs = "1.4.0"

--- a/docs/content/configuration/command-line-arguments.md
+++ b/docs/content/configuration/command-line-arguments.md
@@ -48,6 +48,8 @@ Options:
           Specify the logging output format. Values: json (structured single-line JSON for production) or pretty (human-readable text for development) [env: SERVER_LOG_FORMAT=] [default: json] [possible values: json, pretty]
       --log-with-ansi [<LOG_WITH_ANSI>]
           Enable or disable ANSI escape codes for colors and other text formatting of the log output. Only effective when `--log-format pretty` is used [env: SERVER_LOG_WITH_ANSI=] [default: false] [possible values: true, false]
+      --log-file <LOG_FILE>
+          Optional filesystem path to stream log records to in addition to stderr. When set, logs are written asynchronously through a background worker thread (non-blocking I/O), so the request path is never delayed by disk writes. Missing parent directories are created on startup. ANSI escape codes are always disabled for file output regardless of `--log-with-ansi`. The file uses the format selected by `--log-format` (JSON by default). The file is opened in append mode and is not rotated by SWS, use an external tool (e.g. `logrotate`) for rotation [env: SERVER_LOG_FILE=]
   -c, --cors-allow-origins <CORS_ALLOW_ORIGINS>
           Specify an optional CORS list of allowed origin hosts separated by commas. Host ports or protocols aren't being checked. Use an asterisk (*) to allow any host [env: SERVER_CORS_ALLOW_ORIGINS=] [default: ""]
   -j, --cors-allow-headers <CORS_ALLOW_HEADERS>

--- a/docs/content/configuration/environment-variables.md
+++ b/docs/content/configuration/environment-variables.md
@@ -47,6 +47,10 @@ Enable or disable ANSI escape codes for colors and other text formatting of the 
 
 Log incoming request information along with its Remote Address (IP) if available using the `info` log level. Default `false`.
 
+### SERVER_LOG_FILE
+
+Stream log records to a file on disk in addition to `stderr`. The file is opened in append mode and is not rotated by SWS, use an external tool (e.g. `logrotate`) for rotation. ANSI escape codes are always disabled for file output regardless of `SERVER_LOG_WITH_ANSI`, so the file stays parsable. Default empty (disabled).
+
 ### SERVER_LOG_X_REAL_IP
 
 Log the X-Real-IP header if available using the `info` log level. Default `false`.

--- a/docs/content/features/logging.md
+++ b/docs/content/features/logging.md
@@ -188,3 +188,68 @@ curl "http://[::1]:8080" --header "X-Forwarded-For: <iframe src=//malware.attack
 ```json
 {"timestamp":"2026-05-29T23:43:47.151533+02:00","level":"INFO","message":"incoming request","method":"GET","uri":"/","target":"static_web_server::log_addr"}
 ```
+
+## File Logging
+
+By default **SWS** writes log records to standard error. The `--log-file` option additionally streams every record to a file on disk, in **addition** to `stderr`. This is useful for production deployments where `stderr` is captured by a service manager but a durable on-disk copy is also required.
+
+### Options
+
+| CLI option | Environment variable | TOML key | Description |
+| -- | -- | -- | -- |
+| `--log-file <PATH>` | [`SERVER_LOG_FILE`](../configuration/environment-variables.md#server_log_file) | `log-file` | Filesystem path to stream log records to in addition to `stderr`. Missing parent directories are created on startup. The file is opened in append mode. |
+
+The file uses the format selected by [`--log-format`](./logging.md#log-format) (`json` by default) and the level selected by [`--log-level`](./logging.md#log-level). ANSI escape codes are **always disabled** for file output regardless of `--log-with-ansi`, so the file stays parsable.
+
+### Example
+
+```sh
+static-web-server \
+    --port 8787 \
+    --root ./my-public-dir \
+    --log-level info \
+    --log-format json \
+    --log-file /var/log/sws/server.log
+```
+
+Every log record is now written twice: once to stderr (so `systemd`/`journalctl`, Docker logging drivers, etc. continue to work) and once to `/var/log/sws/server.log`.
+
+### Concurrency and performance
+
+- File writes are performed by a dedicated background worker thread using a lock-free queue. The request path never blocks on disk I/O, regardless of how slow or congested the underlying filesystem is.
+- The default queue capacity (`128,000` lines) is large enough that messages are dropped only under extreme back-pressure, as a right trade-off for a server hot path where blocking the request path on disk would be far worse than losing a debug line.
+- File writes are **append-only**: SWS never rewrites or truncates the log file, so log shippers (Fluent Bit, Vector, Filebeat, etc.) can tail it safely.
+
+### Log rotation
+
+SWS does **not** rotate the file itself. Use an external tool such as [`logrotate`](https://linux.die.net/man/8/logrotate) with the `copytruncate` strategy, or have your log shipper rotate via `dateext` on a schedule. A minimal `logrotate.d` snippet:
+
+```text
+/var/log/sws/server.log {
+    daily
+    rotate 14
+    compress
+    missingok
+    notifempty
+    copytruncate
+}
+```
+
+`copytruncate` is recommended because SWS keeps the file descriptor open for the lifetime of the process, a plain `move + create` rotation would leave SWS writing to the rotated (now-renamed) file until restart.
+
+### TOML configuration
+
+```toml
+[general]
+log-level = "info"
+log-format = "json"
+log-file = "/var/log/sws/server.log"
+```
+
+### Permissions
+
+The log file and any missing parent directories are created with the process umask. To restrict access, set a tighter umask before launching SWS, or create the directory with the desired ownership and mode ahead of time:
+
+```sh
+install -d -m 0750 -o sws -g sws /var/log/sws
+```

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -5,10 +5,20 @@
 
 //! Provides logging initialization for the web server.
 //!
+//! Logs are emitted to stderr by default. When a file path is supplied via
+//! [`init`]'s `log_file` parameter (CLI: `--log-file`, env:
+//! `SERVER_LOG_FILE`, config: `log-file`) the server additionally streams logs
+//! to that file using [`tracing_appender::non_blocking`]. A background thread
+//! drains a lock-free queue so the request path is never blocked by disk I/O.
+//! ANSI escape codes are always disabled for file output regardless of
+//! `--log-with-ansi`.
 
 use clap::ValueEnum;
 use serde::{Deserialize, Serialize};
+use std::path::Path;
+use std::sync::OnceLock;
 use tracing::Level;
+use tracing_appender::non_blocking::{NonBlocking, WorkerGuard};
 use tracing_subscriber::{
     filter::Targets,
     fmt::{format::FmtSpan, time},
@@ -33,49 +43,277 @@ impl std::fmt::Display for LogFormat {
     }
 }
 
+/// Holds the background worker guard for the non-blocking file appender.
+///
+/// The guard MUST live for the entire program duration; dropping it shuts
+/// down the writer thread. Using a `OnceLock` ties its lifetime to the
+/// process. The OS reclaims it on exit. Initialization is intentionally a
+/// one-shot (matching `tracing`'s global subscriber).
+static LOG_FILE_GUARD: OnceLock<WorkerGuard> = OnceLock::new();
+
 /// Logging system initialization.
-pub fn init(log_level: &str, log_format: &LogFormat, log_with_ansi: bool) -> Result {
+///
+/// Sets up a global tracing subscriber that streams events to stderr and,
+/// optionally, to a file. Returns an error if the global subscriber was
+/// already initialized or if the log file cannot be opened.
+pub fn init(
+    log_level: &str,
+    log_format: &LogFormat,
+    log_with_ansi: bool,
+    log_file: Option<&Path>,
+) -> Result {
     let log_level = log_level.to_lowercase();
 
-    configure(&log_level, log_format, log_with_ansi)
+    configure(&log_level, log_format, log_with_ansi, log_file)
         .with_context(|| "failed to initialize logging")?;
 
     Ok(())
 }
 
-/// Initialize logging builder with its level and output format.
-fn configure(level: &str, format: &LogFormat, enable_ansi: bool) -> Result {
+/// Initialize logging builder with its level, output format, and optional
+/// file destination.
+fn configure(
+    level: &str,
+    format: &LogFormat,
+    enable_ansi: bool,
+    log_file: Option<&Path>,
+) -> Result {
     let level = level
         .parse::<Level>()
         .with_context(|| "failed to parse log level")?;
-    let filter = Targets::default().with_default(level);
+    // The same level is applied to both stderr and file layers.
+    let make_filter = || Targets::default().with_default(level);
     let timer = time::LocalTime::rfc_3339();
+
+    // Build the optional file writer first so any I/O failure (path
+    // resolution, file open) is reported before installing the global
+    // subscriber.
+    let (file_writer, file_guard) = match log_file {
+        Some(path) => {
+            let (w, guard) = build_file_writer(path)
+                .with_context(|| format!("failed to open log file: {}", path.display()))?;
+            (Some(w), Some(guard))
+        }
+        None => (None, None),
+    };
+
+    let registry = tracing_subscriber::registry();
 
     let result = match format {
         LogFormat::Json => {
-            let layer = tracing_subscriber::fmt::layer()
+            let stderr_layer = tracing_subscriber::fmt::layer()
                 .json()
                 .flatten_event(true)
                 .with_current_span(false)
                 .with_span_list(false)
                 .with_writer(std::io::stderr)
-                .with_timer(timer)
-                .with_filter(filter);
-            tracing_subscriber::registry().with(layer).try_init()
+                .with_timer(timer.clone())
+                .with_filter(make_filter());
+
+            let file_layer = file_writer.map(|w| {
+                tracing_subscriber::fmt::layer()
+                    .json()
+                    .flatten_event(true)
+                    .with_current_span(false)
+                    .with_span_list(false)
+                    .with_ansi(false)
+                    .with_writer(w)
+                    .with_timer(timer)
+                    .with_filter(make_filter())
+            });
+
+            registry.with(stderr_layer).with(file_layer).try_init()
         }
         LogFormat::Pretty => {
-            let layer = tracing_subscriber::fmt::layer()
+            let stderr_layer = tracing_subscriber::fmt::layer()
                 .with_writer(std::io::stderr)
                 .with_span_events(FmtSpan::CLOSE)
                 .with_ansi(enable_ansi)
-                .with_timer(timer)
-                .with_filter(filter);
-            tracing_subscriber::registry().with(layer).try_init()
+                .with_timer(timer.clone())
+                .with_filter(make_filter());
+
+            let file_layer = file_writer.map(|w| {
+                tracing_subscriber::fmt::layer()
+                    .with_writer(w)
+                    .with_span_events(FmtSpan::CLOSE)
+                    .with_ansi(false)
+                    .with_timer(timer)
+                    .with_filter(make_filter())
+            });
+
+            registry.with(stderr_layer).with(file_layer).try_init()
         }
     };
 
     match result {
+        Ok(()) => {
+            // Store the guard only after the subscriber is installed.
+            if let Some(g) = file_guard {
+                let _ = LOG_FILE_GUARD.set(g);
+            }
+            Ok(())
+        }
         Err(err) => Err(anyhow!(err)),
-        _ => Ok(()),
+    }
+}
+
+/// Build a non-blocking file writer for the given path.
+///
+/// Creates any missing parent directories. Uses
+/// [`tracing_appender::rolling::never`] (no rotation, single file) wrapped in
+/// [`tracing_appender::non_blocking`] so log emission never blocks the request
+/// path; a dedicated background thread drains the queue. The returned guard
+/// keeps the worker thread alive and must outlive every emitter.
+fn build_file_writer(path: &Path) -> Result<(NonBlocking, WorkerGuard)> {
+    let (dir, file_name) = split_path(path)?;
+
+    if !dir.as_os_str().is_empty() {
+        std::fs::create_dir_all(dir)
+            .with_context(|| format!("failed to create log directory: {}", dir.display()))?;
+    }
+
+    // `rolling::never` keeps the file name as-is (no rotation, no date suffix).
+    let appender = tracing_appender::rolling::never(dir, file_name);
+    // Default buffered-lines limit (128k) trades latency for durability:
+    // messages are dropped only under extreme back-pressure, which is the
+    // right trade-off for a server hot path.
+    let (writer, guard) = tracing_appender::non_blocking(appender);
+    Ok((writer, guard))
+}
+
+/// Split a log file path into `(directory, file_name)`.
+///
+/// Returns an error when the path has no file-name component (e.g. ends in a
+/// separator) so misconfiguration is reported at startup rather than producing
+/// silently broken file output.
+fn split_path(path: &Path) -> Result<(&Path, &std::ffi::OsStr)> {
+    let file_name = path.file_name().with_context(|| {
+        format!(
+            "log file path has no file name component: {}",
+            path.display()
+        )
+    })?;
+    let dir = path.parent().unwrap_or_else(|| Path::new(""));
+    Ok((dir, file_name))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `split_path` returns the parent directory and the file-name component
+    /// for a well-formed path.
+    #[test]
+    fn split_path_extracts_dir_and_name() {
+        let path = Path::new("/var/log/sws/server.log");
+        let (dir, name) = split_path(path).expect("split should succeed");
+        assert_eq!(dir, Path::new("/var/log/sws"));
+        assert_eq!(name, std::ffi::OsStr::new("server.log"));
+    }
+
+    /// A bare file name (no directory) is split into an empty directory
+    /// component and the file name itself. Build code skips `create_dir_all`
+    /// in that case.
+    #[test]
+    fn split_path_handles_bare_filename() {
+        let path = Path::new("server.log");
+        let (dir, name) = split_path(path).expect("split should succeed");
+        assert_eq!(dir, Path::new(""));
+        assert_eq!(name, std::ffi::OsStr::new("server.log"));
+    }
+
+    /// A path with no file-name component (e.g. `/`, `..`, `.`) is rejected
+    /// rather than silently producing broken file output. Note that trailing
+    /// separators on otherwise valid paths are normalized by `Path::file_name`
+    /// on Unix, so `/var/log/sws/` is accepted as `sws` in `/var/log`.
+    #[test]
+    fn split_path_rejects_paths_without_file_name() {
+        for bad in ["/", "..", "."] {
+            let res = split_path(Path::new(bad));
+            assert!(
+                res.is_err(),
+                "path {bad:?} should be rejected (no file-name component)"
+            );
+        }
+    }
+
+    /// `build_file_writer` creates missing parent directories on demand.
+    #[test]
+    fn build_file_writer_creates_parent_dirs() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = tmp.path().join("nested/a/b/server.log");
+        let (_writer, _guard) = build_file_writer(&path).expect("build writer");
+        assert!(
+            tmp.path().join("nested/a/b").is_dir(),
+            "parent directories should be created"
+        );
+    }
+
+    /// The non-blocking file writer end-to-end: install a scoped subscriber
+    /// that writes JSON events through `build_file_writer`, emit several log
+    /// statements, drop the guard so the worker thread flushes, then verify
+    /// the file content.
+    ///
+    /// Uses `tracing::subscriber::with_default` (scoped, not global) so this
+    /// test does not collide with the global subscriber installed by other
+    /// integration tests. The scoped subscriber is per-thread, so we emit
+    /// from the calling thread only — thread safety of the underlying queue
+    /// is the responsibility of `tracing-appender::non_blocking` and is
+    /// covered by that crate's own tests.
+    #[test]
+    fn file_writer_streams_events_to_disk() {
+        use std::io::Read;
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let log_path = tmp.path().join("server.log");
+
+        let (writer, guard) = build_file_writer(&log_path).expect("writer");
+        let layer = tracing_subscriber::fmt::layer()
+            .json()
+            .flatten_event(true)
+            .with_current_span(false)
+            .with_span_list(false)
+            .with_ansi(false)
+            .with_writer(writer)
+            .with_filter(Targets::default().with_default(Level::INFO));
+
+        let subscriber = tracing_subscriber::registry().with(layer);
+
+        tracing::subscriber::with_default(subscriber, || {
+            tracing::info!(event = "ready", "first message");
+            tracing::info!(event = "ready", "second message");
+            for i in 0..8 {
+                tracing::info!(worker = i, "burst message");
+            }
+        });
+
+        // Drop the guard so the background worker flushes and closes.
+        drop(guard);
+
+        let mut contents = String::new();
+        std::fs::File::open(&log_path)
+            .expect("open log file")
+            .read_to_string(&mut contents)
+            .expect("read log file");
+
+        assert!(
+            contents.contains("first message"),
+            "expected first message in:\n{contents}"
+        );
+        assert!(
+            contents.contains("second message"),
+            "expected second message in:\n{contents}"
+        );
+        let burst_count = contents.matches("burst message").count();
+        assert_eq!(
+            burst_count, 8,
+            "expected all 8 burst messages; got {burst_count} in:\n{contents}"
+        );
+        // JSON format check: every non-empty line must be a valid JSON object.
+        for line in contents.lines().filter(|l| !l.is_empty()) {
+            let parsed: serde_json::Value = serde_json::from_str(line)
+                .unwrap_or_else(|err| panic!("line is not JSON ({err}): {line}"));
+            assert!(parsed.is_object(), "JSON line must be an object: {line}");
+        }
     }
 }

--- a/src/settings/cli.rs
+++ b/src/settings/cli.rs
@@ -206,6 +206,22 @@ pub struct General {
 
     #[arg(
         long,
+        env = "SERVER_LOG_FILE",
+        value_parser = value_parser_pathbuf,
+    )]
+    /// Optional filesystem path to stream log records to in addition to stderr.
+    /// When set, logs are written asynchronously through a background worker
+    /// thread (non-blocking I/O), so the request path is never delayed by disk
+    /// writes. Missing parent directories are created on startup. ANSI escape
+    /// codes are always disabled for file output regardless of
+    /// `--log-with-ansi`. The file uses the format selected by
+    /// `--log-format` (JSON by default). The file is opened in append mode and
+    /// is not rotated by SWS, use an external tool (e.g. `logrotate`) for
+    /// rotation.
+    pub log_file: Option<PathBuf>,
+
+    #[arg(
+        long,
         short = 'c',
         default_value = "",
         env = "SERVER_CORS_ALLOW_ORIGINS"

--- a/src/settings/file.rs
+++ b/src/settings/file.rs
@@ -213,6 +213,8 @@ pub struct General {
     pub log_with_ansi: Option<bool>,
     /// Logging output format.
     pub log_format: Option<LogFormat>,
+    /// Optional filesystem path to stream log records to in addition to stderr.
+    pub log_file: Option<PathBuf>,
 
     /// Cache Control headers.
     pub cache_control_headers: Option<bool>,

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -138,6 +138,7 @@ impl Settings {
         let mut log_level = opts.log_level;
         let mut log_with_ansi = opts.log_with_ansi;
         let mut log_format = opts.log_format;
+        let mut log_file = opts.log_file.clone();
         let mut config_file = opts.config_file.clone();
         let mut cache_control_headers = opts.cache_control_headers;
         let mut etag = opts.etag;
@@ -272,6 +273,9 @@ impl Settings {
                 }
                 if let Some(v) = general.log_format {
                     log_format = v;
+                }
+                if let Some(v) = general.log_file {
+                    log_file = Some(v);
                 }
                 if let Some(v) = general.cache_control_headers {
                     cache_control_headers = v
@@ -467,7 +471,12 @@ impl Settings {
 
             // Logging system initialization in config file context
             if log_init {
-                logger::init(log_level.as_str(), &log_format, log_with_ansi)?;
+                logger::init(
+                    log_level.as_str(),
+                    &log_format,
+                    log_with_ansi,
+                    log_file.as_deref(),
+                )?;
             }
 
             tracing::debug!("config file read successfully");
@@ -656,7 +665,12 @@ impl Settings {
             }
         } else if log_init {
             // Logging system initialization on demand
-            logger::init(log_level.as_str(), &log_format, log_with_ansi)?;
+            logger::init(
+                log_level.as_str(),
+                &log_format,
+                log_with_ansi,
+                log_file.as_deref(),
+            )?;
         }
 
         // Runtime validation: HTTP/2 requires TLS
@@ -691,6 +705,7 @@ impl Settings {
                 log_level,
                 log_with_ansi,
                 log_format,
+                log_file,
                 config_file,
                 cache_control_headers,
                 etag,

--- a/tests/file_logging.rs
+++ b/tests/file_logging.rs
@@ -1,0 +1,178 @@
+#![forbid(unsafe_code)]
+#![deny(warnings)]
+#![deny(rust_2018_idioms)]
+#![deny(dead_code)]
+
+// Integration tests for file logging (`--log-file` / `SERVER_LOG_FILE` /
+// `log-file`).
+//
+// These tests live in their own integration-test binary so the global
+// `tracing` subscriber installed by `Settings::get_unparsed(true, ..)` does
+// not interfere with other test files. Only ONE test in this file initializes
+// the global subscriber (`writes_logs_to_file_through_settings_init`), since
+// `tracing` allows the global subscriber to be set only once per process.
+
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
+
+use static_web_server::Settings;
+
+/// Poll `path` until it contains `needle` or `timeout` elapses. Returns the
+/// final file content (which may not contain `needle` on timeout) so the
+/// caller can use it in assertion failure messages.
+///
+/// File logging is asynchronous (the non-blocking writer drains on a
+/// background thread), so callers must wait for the worker to flush rather
+/// than reading immediately after emitting a log statement.
+fn wait_for_log_content(path: &std::path::Path, needle: &str, timeout: Duration) -> String {
+    let deadline = Instant::now() + timeout;
+    loop {
+        let contents = std::fs::read_to_string(path).unwrap_or_default();
+        if contents.contains(needle) {
+            return contents;
+        }
+        if Instant::now() >= deadline {
+            return contents;
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+}
+
+/// `--log-file` from CLI must be reflected in resolved settings.
+#[test]
+fn cli_log_file_is_reflected_in_settings() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let log_path = tmp.path().join("sws.log");
+
+    // `log_init=false`: do NOT install the global subscriber from this test.
+    let settings = Settings::get_unparsed(
+        false,
+        &[
+            "static-web-server",
+            "--root",
+            "tests/fixtures/public",
+            "--port",
+            "0",
+            "--log-file",
+            log_path.to_str().unwrap(),
+        ],
+    )
+    .expect("settings must parse");
+
+    assert_eq!(
+        settings.general.log_file,
+        Some(log_path),
+        "--log-file should be reflected in resolved settings"
+    );
+}
+
+/// When no `--log-file` is provided, the resolved setting is `None` so the
+/// logger skips the file layer entirely.
+#[test]
+fn missing_log_file_resolves_to_none() {
+    let settings = Settings::get_unparsed(
+        false,
+        &[
+            "static-web-server",
+            "--root",
+            "tests/fixtures/public",
+            "--port",
+            "0",
+        ],
+    )
+    .expect("settings must parse");
+
+    assert!(
+        settings.general.log_file.is_none(),
+        "log_file must default to None when --log-file is not set"
+    );
+}
+
+/// TOML `log-file` under `[general]` is honored by settings parsing.
+#[test]
+fn toml_log_file_is_reflected_in_settings() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let log_path = tmp.path().join("from-toml.log");
+    let config_path = tmp.path().join("sws.toml");
+
+    // Use `Display::fmt` with proper TOML escaping by double-quoting the path
+    // and replacing backslashes (Windows) / quotes — fine for tempdir paths.
+    let toml = format!(
+        "[general]\nroot = \"tests/fixtures/public\"\nlog-file = \"{}\"\n",
+        log_path.display().to_string().replace('\\', "\\\\")
+    );
+    std::fs::write(&config_path, toml).expect("write toml");
+
+    let settings = Settings::get_unparsed(
+        false,
+        &[
+            "static-web-server",
+            "--config-file",
+            config_path.to_str().unwrap(),
+        ],
+    )
+    .expect("settings must parse");
+
+    assert_eq!(
+        settings.general.log_file,
+        Some(log_path),
+        "log-file from TOML should populate settings.general.log_file"
+    );
+}
+
+/// `Settings::get_unparsed(true, ..)` with `--log-file` installs the global
+/// subscriber, opens the log file, and streams subsequent log events to it
+/// through the non-blocking writer.
+///
+/// This is the ONLY test in this file that calls `log_init=true`, so it must
+/// stay alone, `tracing`'s global subscriber can be installed only once.
+#[test]
+fn writes_logs_to_file_through_settings_init() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let log_path: PathBuf = tmp.path().join("server.log");
+
+    // Initialize the global subscriber with file output enabled. We pick a
+    // generous level so the test event is captured regardless of the default.
+    let _settings = Settings::get_unparsed(
+        true,
+        &[
+            "static-web-server",
+            "--root",
+            "tests/fixtures/public",
+            "--port",
+            "0",
+            "--log-level",
+            "info",
+            "--log-format",
+            "json",
+            "--log-file",
+            log_path.to_str().unwrap(),
+        ],
+    )
+    .expect("settings must parse and logger must initialize");
+
+    // Emit a sentinel event that should reach the file via the non-blocking
+    // worker thread.
+    tracing::info!(test = "file-logging", "file-logging-integration-test");
+
+    // Wait up to 3s for the background writer to flush the entry.
+    let contents = wait_for_log_content(
+        &log_path,
+        "file-logging-integration-test",
+        Duration::from_secs(3),
+    );
+    assert!(
+        contents.contains("file-logging-integration-test"),
+        "expected log message in file; got:\n{contents}"
+    );
+
+    // The chosen format is JSON, so every non-empty line must be valid JSON.
+    for line in contents.lines().filter(|l| !l.is_empty()) {
+        let parsed: serde_json::Value = serde_json::from_str(line)
+            .unwrap_or_else(|err| panic!("log line is not valid JSON ({err}): {line}"));
+        assert!(
+            parsed.is_object(),
+            "JSON log line must be an object: {line}"
+        );
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Read the docs/PULL_REQUESTS.md -->

## Description
<!--- Describe your changes but try to be as concise as possible -->

This PR adds support for File Logging to write log records to a file on disk, in addition to `stderr`. It is useful for production deployments where `stderr` is captured by a service manager, but a durable on-disk copy is also required.

`--log-file <PATH>` (`SERVER_LOG_FILE`): Filesystem path to stream log records to in addition to stderr. Missing parent directories are created on startup. The file is opened in append mode.

The file uses the format selected by `--log-format` (`json` by default) and the level selected by `--log-level`.
ANSI escape codes are always disabled for file output regardless of `--log-with-ansi`, so the file stays parsable.

**Example**

```sh
static-web-server \
    --port 8787 \
    --root ./my-public-dir \
    --log-level info \
    --log-format json \
    --log-file /var/log/sws/server.log
```

Note that SWS does not rotate the file itself, so an external tool such as [logrotate](https://linux.die.net/man/8/logrotate) could be used.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- See how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
