### PR TITLE
Fix unnecessary pre-compressed file look up when the uncompressed one doesn't exist

### DIFF
--- a/src/static_files/resolve.rs
+++ b/src/static_files/resolve.rs
@@ -39,39 +39,32 @@ pub(super) fn file_metadata<'a>(
             // extra `open(2)` syscall. We only populate it when the index
             // file is resolved via `try_file_open` below.
             let mut opened_file = None;
+            // Whether the resolved `file_path` points to an existing file.
+            // For non-directory requests this is always true.
+            // For directory requests it becomes true only when an index file (or its
+            // `.html` suffix sibling) was successfully resolved. Used to
+            // gate the pre-compressed variant probe so we never issue
+            // `stat(2)` for `.br`/`.gz`/`.zst` siblings of a non-existent
+            // index (see issue #617).
+            let mut resolved_exists = !is_dir;
             if is_dir {
                 if index_files.is_empty() {
                     index_files = DEFAULT_INDEX_FILES;
                 }
-                let mut index_found = false;
                 for index in index_files {
                     // Append a HTML index page by default if it's a directory path (`autoindex`).
                     tracing::debug!("dir: appending {} to the directory path", index);
                     file_path.push(index);
 
-                    if compression_static
-                        && let Some(p) =
-                            compression_static::precompressed_variant(file_path, headers)
-                    {
-                        return Ok(FileMetadata {
-                            file_path,
-                            metadata: p.metadata,
-                            is_dir: false,
-                            precompressed_variant: Some((p.file_path, p.encoding)),
-                            file: None,
-                        });
-                    }
-
-                    // Fallback to finding the appended index file and overwrite the
-                    // current metadata. Still considered a directory request.
-                    // We open the file directly here: `try_file_open` performs
-                    // a single `open(2)` + `fstat(2)` instead of a `stat(2)`
-                    // followed by an `open(2)` later in `file_reply`,
-                    // saving one path-resolving syscall on the hot path.
+                    // Try to open the appended index file directly.
+                    // `try_file_open` performs a single `open(2)` + `fstat(2)`
+                    // instead of `stat(2)` followed by `open(2)` later in
+                    // `file_reply`, saving one path-resolving syscall on the
+                    // hot path.
                     if let Ok((file, meta)) = try_file_open(file_path) {
                         metadata = meta;
                         opened_file = Some(file);
-                        index_found = true;
+                        resolved_exists = true;
                         break;
                     }
 
@@ -82,19 +75,24 @@ pub(super) fn file_metadata<'a>(
                     (file_path, new_meta) = try_metadata_with_html_suffix(file_path);
                     if let Some(new_meta) = new_meta {
                         metadata = new_meta;
-                        index_found = true;
+                        resolved_exists = true;
                         break;
                     }
                 }
 
                 // If no index was found, append the last index of the list
                 // to preserve the original directory-listing behavior.
-                if !index_found && !index_files.is_empty() {
+                if !resolved_exists && !index_files.is_empty() {
                     file_path.push(index_files.last().unwrap());
                 }
             }
 
-            let precompressed_variant = compression_static
+            // Only probe for pre-compressed siblings when the resolved file
+            // actually exists. Probing for `.br`/`.gz`/`.zst` of a path that
+            // was never confirmed on disk wastes one `stat(2)` per
+            // configured encoding on the request hot path
+            // (see issue #617).
+            let precompressed_variant = (compression_static && resolved_exists)
                 .then(|| compression_static::precompressed_variant(file_path, headers))
                 .flatten()
                 .map(|p| (p.file_path, p.encoding));
@@ -115,69 +113,38 @@ pub(super) fn file_metadata<'a>(
             })
         }
         Err(err) => {
-            // Pre-compressed variant check for a file that was not found.
-            if compression_static
-                && let Some(p) = compression_static::precompressed_variant(file_path, headers)
-            {
-                return Ok(FileMetadata {
-                    file_path,
-                    metadata: p.metadata,
-                    is_dir: false,
-                    precompressed_variant: Some((p.file_path, p.encoding)),
-                    file: None,
-                });
-            }
-
-            // Otherwise, if the file path doesn't exist try the `.html`-suffixed path.
-            // For example: `/posts/article` falls back to `/posts/article.html`.
+            // If the file path doesn't exist, then try the `.html`-suffixed path
+            // first. For example: `/posts/article` falls back to
+            // `/posts/article.html`.
+            //
+            // We intentionally do *not* probe for pre-compressed siblings
+            // of the original (non-existent) path. Doing so would waste
+            // one `stat(2)` per configured encoding for every truly
+            // missing path (see issue #617).
             let new_meta: Option<Metadata>;
             (file_path, new_meta) = try_metadata_with_html_suffix(file_path);
 
-            #[cfg(any(
-                feature = "compression",
-                feature = "compression-deflate",
-                feature = "compression-gzip",
-                feature = "compression-brotli",
-                feature = "compression-zstd"
-            ))]
-            match new_meta {
-                Some(new_meta) => {
-                    return Ok(FileMetadata {
-                        file_path,
-                        metadata: new_meta,
-                        is_dir: false,
-                        precompressed_variant: None,
-                        file: None,
-                    });
-                }
-                _ => {
-                    // Last pre-compressed variant check for the suffixed file.
-                    if compression_static
-                        && let Some(p) =
-                            compression_static::precompressed_variant(file_path, headers)
-                    {
-                        return Ok(FileMetadata {
-                            file_path,
-                            metadata: p.metadata,
-                            is_dir: false,
-                            precompressed_variant: Some((p.file_path, p.encoding)),
-                            file: None,
-                        });
-                    }
-                }
-            }
-            #[cfg(not(feature = "compression"))]
-            if let Some(new_meta) = new_meta {
-                return Ok(FileMetadata {
-                    file_path,
-                    metadata: new_meta,
-                    is_dir: false,
-                    precompressed_variant: None,
-                    file: None,
-                });
-            }
+            let Some(new_meta) = new_meta else {
+                // Neither the original path nor its `.html` sibling exists.
+                // Return the original error without probing for compressed
+                // variants of non-existent files.
+                return Err(err);
+            };
 
-            Err(err)
+            // The `.html` sibling exists. Only now is it worth probing for
+            // its pre-compressed sibling (`/article.html.br`, etc.).
+            let precompressed_variant = compression_static
+                .then(|| compression_static::precompressed_variant(file_path, headers))
+                .flatten()
+                .map(|p| (p.file_path, p.encoding));
+
+            Ok(FileMetadata {
+                file_path,
+                metadata: new_meta,
+                is_dir: false,
+                precompressed_variant,
+                file: None,
+            })
         }
     }
 }

--- a/tests/compression_static.rs
+++ b/tests/compression_static.rs
@@ -290,4 +290,162 @@ mod tests {
             Err(err) => panic!("unexpected error: {err}"),
         }
     }
+
+    /// When the requested path does not exist on disk and no `.html`-suffixed
+    /// sibling exists either, SWS must return 404 without probing for
+    /// pre-compressed (`.br`/`.gz`/`.zst`) siblings of the missing path.
+    /// See issue #617 for the rationale behind this behavior.
+    #[tokio::test]
+    async fn compression_static_missing_file_skips_precompressed_probes() {
+        let opts = fixture_settings("toml/handler_fixtures.toml");
+        let general = General {
+            #[cfg(any(
+                feature = "compression",
+                feature = "compression-gzip",
+                feature = "compression-brotli",
+                feature = "compression-zstd",
+                feature = "compression-deflate"
+            ))]
+            compression: false,
+            compression_static: true,
+            etag: true,
+            ..opts.general
+        };
+        let req_handler_opts = fixture_req_handler_opts(general, opts.advanced);
+        let req_handler = fixture_req_handler(req_handler_opts);
+
+        let mut req = Request::new(());
+        *req.method_mut() = hyper::Method::GET;
+        *req.uri_mut() = "http://localhost/this-path-does-not-exist".parse().unwrap();
+        req.headers_mut().insert(
+            http::header::ACCEPT_ENCODING,
+            "gzip, deflate, br, zstd".parse().unwrap(),
+        );
+
+        let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
+        match req_handler.handle(&mut req, remote_addr).await {
+            Ok(res) => {
+                assert_eq!(res.status(), 404);
+                assert!(!res.headers().contains_key("content-encoding"));
+            }
+            Err(err) => panic!("unexpected error: {err}"),
+        }
+    }
+
+    /// When the requested path does not exist but its `.html`-suffixed
+    /// sibling does, SWS must resolve the suffixed path and, if a
+    /// pre-compressed sibling of *that* `.html` file exists, serve it.
+    ///
+    /// Before the issue #617 fix the pre-compressed `.html` sibling was
+    /// ignored on the html-suffix fallback path.
+    #[tokio::test]
+    async fn compression_static_html_suffix_serves_precompressed_variant() {
+        let archive_path = PathBuf::from("tests/fixtures/public/404.html.br");
+        let archive_buf =
+            std::fs::read(&archive_path).expect("unexpected error when reading archive file");
+        let archive_buf = Bytes::from(archive_buf);
+
+        let opts = fixture_settings("toml/handler_fixtures.toml");
+        let general = General {
+            #[cfg(any(
+                feature = "compression",
+                feature = "compression-gzip",
+                feature = "compression-brotli",
+                feature = "compression-zstd",
+                feature = "compression-deflate"
+            ))]
+            compression: false,
+            compression_static: true,
+            etag: true,
+            ..opts.general
+        };
+        let req_handler_opts = fixture_req_handler_opts(general, opts.advanced);
+        let req_handler = fixture_req_handler(req_handler_opts);
+
+        // Request `/404` (no extension): SWS appends `.html`, finds
+        // `404.html`, and should then serve the pre-compressed
+        // `404.html.br` sibling.
+        let mut req = Request::new(());
+        *req.method_mut() = hyper::Method::GET;
+        *req.uri_mut() = "http://localhost/404".parse().unwrap();
+        req.headers_mut().insert(
+            http::header::ACCEPT_ENCODING,
+            "gzip, deflate, br, zstd".parse().unwrap(),
+        );
+
+        let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
+        match req_handler.handle(&mut req, remote_addr).await {
+            Ok(res) => {
+                let headers = res.headers();
+
+                assert_eq!(res.status(), 200);
+                assert_eq!(headers["content-encoding"], "br");
+                assert_eq!(headers["vary"], "accept-encoding");
+                assert_eq!(
+                    &headers["content-type"], "text/html; charset=utf-8",
+                    "content-type is not html"
+                );
+
+                let body = res
+                    .into_body()
+                    .collect()
+                    .await
+                    .expect("unexpected bytes error during `body` conversion")
+                    .to_bytes();
+
+                assert_eq!(body, archive_buf, "body must equal the .html.br archive");
+            }
+            Err(err) => panic!("unexpected error: {err}"),
+        }
+    }
+
+    /// When a directory has no index file at all, SWS must fall back to
+    /// the directory listing (or 404 when listing is disabled) without
+    /// probing for pre-compressed siblings of the non-existent index.
+    ///
+    /// Regression for issue #617: previously the in-loop and post-loop
+    /// pre-compressed probes ran even when the index file did not exist,
+    /// wasting `stat(2)` syscalls per configured encoding.
+    #[tokio::test]
+    async fn compression_static_missing_index_skips_precompressed_probes() {
+        let opts = fixture_settings("toml/handler_fixtures.toml");
+        let general = General {
+            #[cfg(any(
+                feature = "compression",
+                feature = "compression-gzip",
+                feature = "compression-brotli",
+                feature = "compression-zstd",
+                feature = "compression-deflate"
+            ))]
+            compression: false,
+            compression_static: true,
+            etag: true,
+            // Use only an index name that does not exist in `assets/` so
+            // SWS exercises the no-index-found branch.
+            index_files: "missing-index.html".to_owned(),
+            ..opts.general
+        };
+        let req_handler_opts = fixture_req_handler_opts(general, opts.advanced);
+        let req_handler = fixture_req_handler(req_handler_opts);
+
+        let mut req = Request::new(());
+        *req.method_mut() = hyper::Method::GET;
+        *req.uri_mut() = "http://localhost/assets/".parse().unwrap();
+        req.headers_mut().insert(
+            http::header::ACCEPT_ENCODING,
+            "gzip, deflate, br, zstd".parse().unwrap(),
+        );
+
+        let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
+        match req_handler.handle(&mut req, remote_addr).await {
+            Ok(res) => {
+                // Directory listing is disabled in the default fixture, so
+                // the response must be a plain 404 with no content-encoding
+                // header from a stray pre-compressed match.
+                assert_eq!(res.status(), 404);
+                assert!(!res.headers().contains_key("content-encoding"));
+            }
+            Err(err) => panic!("unexpected error: {err}"),
+        }
+    }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Read the docs/PULL_REQUESTS.md -->

## Description
<!--- Describe your changes but try to be as concise as possible -->

This PR fixes an issue when SWS was unnecessarily looking up the pre-compressed variant of a file when it was not confirmed to exist, wasting up to 3 `stat(2)` syscalls per `404`.

The following use cases are now properly covered:

- **Missing file with no `.html` sibling** returns `404` immediately with zero pre-compressed probes (no wasted `stat(2)` for `.br`/`.gz`/`.zst` on non-existent paths).
- **Missing file resolved via `.html` suffix fallback** now correctly probes for and serves the pre-compressed sibling of the `.html` file (e.g., `GET /404` to `404.html.br`), which was previously broken.
- **Directory with no existing index file** falls back to `404` or directory listing without probing pre-compressed siblings of the missing index entries.
- **Existing file with pre-compressed variant** (unchanged behavior preserved): probes for and serves the best-matching `.br`/`.gz`/`.zst` sibling.
- **Directory with an existing index file** (unchanged behavior preserved): probes for and serves the pre-compressed sibling of the resolved index.
- **File metadata error path (`try_metadata` failure)** tries `.html` suffix first; if that also fails, returns the original error without any pre-compressed probing.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

It fixes #617.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- See how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
