### PR TITLE
Unnecessary pre-compressed look up if uncompressed file doesn't exist (backport)

### DIFF
--- a/src/static_files.rs
+++ b/src/static_files.rs
@@ -19,7 +19,7 @@ use std::path::{Path, PathBuf};
 
 use crate::Result;
 use crate::conditional_headers::ConditionalHeaders;
-use crate::fs::meta::{FileMetadata, try_metadata, try_metadata_with_html_suffix};
+use crate::fs::meta::{FileMetadata, try_file_open, try_metadata, try_metadata_with_html_suffix};
 use crate::fs::path::{PathExt, sanitize_path};
 use crate::http_ext::{HTTP_SUPPORTED_METHODS, MethodExt};
 use crate::response::response_body;
@@ -455,42 +455,33 @@ fn get_composed_file_metadata<'a>(
             // extra `open(2)` syscall. We only populate it when the index
             // file is resolved via `try_file_open` below.
             let mut opened_file = None;
+            // Whether the resolved `file_path` points to an existing file.
+            // For non-directory requests this is always true.
+            // For directory requests it becomes true only when an index file (or its
+            // `.html` suffix sibling) was successfully resolved. Used to
+            // gate the pre-compressed variant probe so we never issue
+            // `stat(2)` for `.br`/`.gz`/`.zst` siblings of a non-existent
+            // index (see issue #617).
+            let mut resolved_exists = !is_dir;
             if is_dir {
                 // Try every index file variant in order
                 if index_files.is_empty() {
                     index_files = DEFAULT_INDEX_FILES;
                 }
-                let mut index_found = false;
                 for index in index_files {
                     // Append a HTML index page by default if it's a directory path (`autoindex`)
                     tracing::debug!("dir: appending {} to the directory path", index);
                     file_path.push(index);
 
-                    if compression_static
-                        && let Some(p) =
-                            compression_static::precompressed_variant(file_path, headers)
-                    {
-                        return Ok(FileMetadata {
-                            file_path,
-                            metadata: p.metadata,
-                            is_dir: false,
-                            precompressed_variant: Some((p.file_path, p.encoding)),
-                            file: None,
-                        });
-                    }
-
-                    // Otherwise, just fallback to finding the index.html
-                    // and overwrite the current `meta`
-                    // Also noting that it's still a directory request.
-                    //
-                    // We open the file directly here: `try_file_open` performs
-                    // a single `open(2)` + `fstat(2)` instead of a `stat(2)`
-                    // followed by an `open(2)` later in `file_reply`,
-                    // saving one path-resolving syscall on the hot path.
-                    if let Ok((file, meta)) = crate::fs::meta::try_file_open(file_path) {
+                    // Try to open the appended index file directly.
+                    // `try_file_open` performs a single `open(2)` + `fstat(2)`
+                    // instead of `stat(2)` followed by `open(2)` later in
+                    // `file_reply`, saving one path-resolving syscall on the
+                    // hot path.
+                    if let Ok((file, meta)) = try_file_open(file_path) {
                         metadata = meta;
                         opened_file = Some(file);
-                        index_found = true;
+                        resolved_exists = true;
                         break;
                     }
 
@@ -500,19 +491,24 @@ fn get_composed_file_metadata<'a>(
                     (file_path, new_meta) = try_metadata_with_html_suffix(file_path);
                     if let Some(new_meta) = new_meta {
                         metadata = new_meta;
-                        index_found = true;
+                        resolved_exists = true;
                         break;
                     }
                 }
 
                 // In case no index was found then we append the last index
                 // of the list to preserve the previous behavior
-                if !index_found && !index_files.is_empty() {
+                if !resolved_exists && !index_files.is_empty() {
                     file_path.push(index_files.last().unwrap());
                 }
             }
 
-            let precompressed_variant = compression_static
+            // Only probe for pre-compressed siblings when the resolved file
+            // actually exists. Probing for `.br`/`.gz`/`.zst` of a path that
+            // was never confirmed on disk wastes one `stat(2)` per
+            // configured encoding on the request hot path
+            // (see issue #617).
+            let precompressed_variant = (compression_static && resolved_exists)
                 .then(|| compression_static::precompressed_variant(file_path, headers))
                 .flatten()
                 .map(|p| (p.file_path, p.encoding));
@@ -533,70 +529,38 @@ fn get_composed_file_metadata<'a>(
             })
         }
         Err(err) => {
-            // Pre-compressed variant check for the file not found
-            if compression_static
-                && let Some(p) = compression_static::precompressed_variant(file_path, headers)
-            {
-                return Ok(FileMetadata {
-                    file_path,
-                    metadata: p.metadata,
-                    is_dir: false,
-                    precompressed_variant: Some((p.file_path, p.encoding)),
-                    file: None,
-                });
-            }
-
-            // Otherwise, if the file path doesn't exist then
-            // we try to find the path suffixed with `.html`.
-            // For example: `/posts/article` will fallback to `/posts/article.html`
+            // If the file path doesn't exist, then try the `.html`-suffixed path
+            // first. For example: `/posts/article` falls back to
+            // `/posts/article.html`.
+            //
+            // We intentionally do *not* probe for pre-compressed siblings
+            // of the original (non-existent) path. Doing so would waste
+            // one `stat(2)` per configured encoding for every truly
+            // missing path (see issue #617).
             let new_meta: Option<Metadata>;
             (file_path, new_meta) = try_metadata_with_html_suffix(file_path);
 
-            #[cfg(any(
-                feature = "compression",
-                feature = "compression-deflate",
-                feature = "compression-gzip",
-                feature = "compression-brotli",
-                feature = "compression-zstd"
-            ))]
-            match new_meta {
-                Some(new_meta) => {
-                    return Ok(FileMetadata {
-                        file_path,
-                        metadata: new_meta,
-                        is_dir: false,
-                        precompressed_variant: None,
-                        file: None,
-                    });
-                }
-                _ => {
-                    // Last pre-compressed variant check or the suffixed file not found
-                    if compression_static
-                        && let Some(p) =
-                            compression_static::precompressed_variant(file_path, headers)
-                    {
-                        return Ok(FileMetadata {
-                            file_path,
-                            metadata: p.metadata,
-                            is_dir: false,
-                            precompressed_variant: Some((p.file_path, p.encoding)),
-                            file: None,
-                        });
-                    }
-                }
-            }
-            #[cfg(not(feature = "compression"))]
-            if let Some(new_meta) = new_meta {
-                return Ok(FileMetadata {
-                    file_path,
-                    metadata: new_meta,
-                    is_dir: false,
-                    precompressed_variant: None,
-                    file: None,
-                });
-            }
+            let Some(new_meta) = new_meta else {
+                // Neither the original path nor its `.html` sibling exists.
+                // Return the original error without probing for compressed
+                // variants of non-existent files.
+                return Err(err);
+            };
 
-            Err(err)
+            // The `.html` sibling exists. Only now is it worth probing for
+            // its pre-compressed sibling (`/article.html.br`, etc.).
+            let precompressed_variant = compression_static
+                .then(|| compression_static::precompressed_variant(file_path, headers))
+                .flatten()
+                .map(|p| (p.file_path, p.encoding));
+
+            Ok(FileMetadata {
+                file_path,
+                metadata: new_meta,
+                is_dir: false,
+                precompressed_variant,
+                file: None,
+            })
         }
     }
 }

--- a/tests/compression_static.rs
+++ b/tests/compression_static.rs
@@ -261,4 +261,135 @@ mod tests {
             Err(err) => panic!("unexpected error: {err}"),
         }
     }
+
+    /// When the requested path does not exist on disk and no `.html`-suffixed
+    /// sibling exists either, SWS must return 404 without probing for
+    /// pre-compressed (`.br`/`.gz`/`.zst`) siblings of the missing path.
+    /// See issue #617 for the rationale behind this behavior.
+    #[tokio::test]
+    async fn compression_static_missing_file_skips_precompressed_probes() {
+        let opts = fixture_settings("toml/handler_fixtures.toml");
+        let general = General {
+            compression: false,
+            compression_static: true,
+            ..opts.general
+        };
+        let req_handler_opts = fixture_req_handler_opts(general, opts.advanced);
+        let req_handler = fixture_req_handler(req_handler_opts);
+
+        let mut req = Request::default();
+        *req.method_mut() = hyper::Method::GET;
+        *req.uri_mut() = "http://localhost/this-path-does-not-exist".parse().unwrap();
+        req.headers_mut().insert(
+            http::header::ACCEPT_ENCODING,
+            "gzip, deflate, br, zstd".parse().unwrap(),
+        );
+
+        let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
+        match req_handler.handle(&mut req, remote_addr).await {
+            Ok(res) => {
+                assert_eq!(res.status(), 404);
+                assert!(!res.headers().contains_key("content-encoding"));
+            }
+            Err(err) => panic!("unexpected error: {err}"),
+        }
+    }
+
+    /// When the requested path does not exist but its `.html`-suffixed
+    /// sibling does, SWS must resolve the suffixed path and, if a
+    /// pre-compressed sibling of *that* `.html` file exists, serve it.
+    ///
+    /// Before the issue #617 fix the pre-compressed `.html` sibling was
+    /// ignored on the html-suffix fallback path.
+    #[tokio::test]
+    async fn compression_static_html_suffix_serves_precompressed_variant() {
+        let archive_path = PathBuf::from("tests/fixtures/public/404.html.br");
+        let archive_buf =
+            std::fs::read(&archive_path).expect("unexpected error when reading archive file");
+        let archive_buf = Bytes::from(archive_buf);
+
+        let opts = fixture_settings("toml/handler_fixtures.toml");
+        let general = General {
+            compression: false,
+            compression_static: true,
+            ..opts.general
+        };
+        let req_handler_opts = fixture_req_handler_opts(general, opts.advanced);
+        let req_handler = fixture_req_handler(req_handler_opts);
+
+        // Request `/404` (no extension): SWS appends `.html`, finds
+        // `404.html`, and should then serve the pre-compressed
+        // `404.html.br` sibling.
+        let mut req = Request::default();
+        *req.method_mut() = hyper::Method::GET;
+        *req.uri_mut() = "http://localhost/404".parse().unwrap();
+        req.headers_mut().insert(
+            http::header::ACCEPT_ENCODING,
+            "gzip, deflate, br, zstd".parse().unwrap(),
+        );
+
+        let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
+        match req_handler.handle(&mut req, remote_addr).await {
+            Ok(mut res) => {
+                let headers = res.headers();
+
+                assert_eq!(res.status(), 200);
+                assert_eq!(headers["content-encoding"], "br");
+                assert_eq!(headers["vary"], "accept-encoding");
+                assert_eq!(
+                    &headers["content-type"], "text/html; charset=utf-8",
+                    "content-type is not html"
+                );
+
+                let body = hyper::body::to_bytes(res.body_mut())
+                    .await
+                    .expect("unexpected bytes error during `body` conversion");
+
+                assert_eq!(body, archive_buf, "body must equal the .html.br archive");
+            }
+            Err(err) => panic!("unexpected error: {err}"),
+        }
+    }
+
+    /// When a directory has no index file at all, SWS must fall back to
+    /// the directory listing (or 404 when listing is disabled) without
+    /// probing for pre-compressed siblings of the non-existent index.
+    ///
+    /// Regression for issue #617: previously the in-loop and post-loop
+    /// pre-compressed probes ran even when the index file did not exist,
+    /// wasting `stat(2)` syscalls per configured encoding.
+    #[tokio::test]
+    async fn compression_static_missing_index_skips_precompressed_probes() {
+        let opts = fixture_settings("toml/handler_fixtures.toml");
+        let general = General {
+            compression: false,
+            compression_static: true,
+            // Use only an index name that does not exist in `assets/` so
+            // SWS exercises the no-index-found branch.
+            index_files: "missing-index.html".to_owned(),
+            ..opts.general
+        };
+        let req_handler_opts = fixture_req_handler_opts(general, opts.advanced);
+        let req_handler = fixture_req_handler(req_handler_opts);
+
+        let mut req = Request::default();
+        *req.method_mut() = hyper::Method::GET;
+        *req.uri_mut() = "http://localhost/assets/".parse().unwrap();
+        req.headers_mut().insert(
+            http::header::ACCEPT_ENCODING,
+            "gzip, deflate, br, zstd".parse().unwrap(),
+        );
+
+        let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
+        match req_handler.handle(&mut req, remote_addr).await {
+            Ok(res) => {
+                // Directory listing is disabled in the default fixture, so
+                // the response must be a plain 404 with no content-encoding
+                // header from a stray pre-compressed match.
+                assert_eq!(res.status(), 404);
+                assert!(!res.headers().contains_key("content-encoding"));
+            }
+            Err(err) => panic!("unexpected error: {err}"),
+        }
+    }
 }


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->
<!--- Read the docs/PULL_REQUESTS.md -->

## Description
<!--- Describe your changes but try to be as concise as possible -->
This is a bug fix backported from https://github.com/static-web-server/static-web-server/pull/683.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

It fixes #617.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- See how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
