### PR TITLE
Add missing `.html` suffix for 404s description

### DIFF
--- a/docs/content/features/error-pages.md
+++ b/docs/content/features/error-pages.md
@@ -18,6 +18,10 @@ static-web-server \
     --page50x ./my-page-50x.html
 ```
 
+## Default `.html` suffixes
+
+If a page does not exist at the specified path, **SWS** will attempt to serve a page with the same path but with an `.html` suffix. For example, if `--page404` is set to `./my-page-404` and that file does not exist, **SWS** will look for `./my-page-404.html` and serve it if found. This allows for convenient configuration without needing to specify the `.html` extension if your error pages are named with that suffix.
+
 ## Fallback Page for use with Client Routers
 
 It is possible to provide a HTML file to be used as fallback page when `GET` request paths dont exist.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Read the docs/PULL_REQUESTS.md -->

## Description
<!--- Describe your changes but try to be as concise as possible -->

This PR adds the missing `.html` suffix to the docs for the https://github.com/static-web-server/static-web-server/pull/180.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- See how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
