### PR TITLE
Preserve query string on URL redirects (v2 backport)

### DIFF
--- a/src/redirects.rs
+++ b/src/redirects.rs
@@ -62,7 +62,7 @@ pub(crate) fn pre_process<T>(
         uri_host.push_str(&format!(":{uri_port}"));
     }
     let matched = get_redirection(&uri_host, uri_path, Some(redirects))?;
-    let dest = match replace_placeholders(
+    let mut dest = match replace_placeholders(
         uri_path,
         &matched.source,
         &matched.destination,
@@ -71,6 +71,15 @@ pub(crate) fn pre_process<T>(
         Ok(dest) => dest,
         Err(err) => return handle_error(err, opts, req),
     };
+
+    // Preserve the client's query string across the redirect
+    // in an Apache's QSA rewrite option fashion.
+    if let Some(query) = uri.query() {
+        if !dest.ends_with('?') && !dest.ends_with('&') {
+            dest.push(if dest.contains('?') { '&' } else { '?' });
+        }
+        dest.push_str(query);
+    }
 
     match HeaderValue::from_str(&dest) {
         Ok(loc) => {
@@ -198,6 +207,8 @@ mod tests {
         let r2 = build_placeholder_replacer(&s2);
         let s3 = Regex::new(r"/(prefix/)?(source3)/(.*)").unwrap();
         let r3 = build_placeholder_replacer(&s3);
+        let s4 = Regex::new(r"/source4/(.*)").unwrap();
+        let r4 = build_placeholder_replacer(&s4);
         vec![
             Redirects {
                 host: None,
@@ -219,6 +230,13 @@ mod tests {
                 destination: "/destination3/$2/$3".into(),
                 kind: StatusCode::MOVED_PERMANENTLY,
                 replacer: r3,
+            },
+            Redirects {
+                host: None,
+                source: s4,
+                destination: "/destination4?p=$1".into(),
+                kind: StatusCode::FOUND,
+                replacer: r4,
             },
         ]
     }
@@ -335,6 +353,88 @@ mod tests {
             Some((
                 StatusCode::MOVED_PERMANENTLY,
                 "/destination3/source3/whatever".into()
+            ))
+        );
+
+        assert_eq!(
+            is_redirect(pre_process(
+                &RequestHandlerOpts {
+                    advanced_opts: Some(Advanced {
+                        redirects: Some(get_redirects()),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                },
+                &make_request("", "/source4/whatever")
+            )),
+            Some((StatusCode::FOUND, "/destination4?p=whatever".into()))
+        );
+    }
+
+    #[test]
+    fn test_query() {
+        assert_eq!(
+            is_redirect(pre_process(
+                &RequestHandlerOpts {
+                    advanced_opts: Some(Advanced {
+                        redirects: Some(get_redirects()),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                },
+                &make_request("", "/source1?q=query-string")
+            )),
+            Some((StatusCode::FOUND, "/destination1?q=query-string".into()))
+        );
+
+        assert_eq!(
+            is_redirect(pre_process(
+                &RequestHandlerOpts {
+                    advanced_opts: Some(Advanced {
+                        redirects: Some(get_redirects()),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                },
+                &make_request("example.com", "/source2?q=query-string")
+            )),
+            Some((
+                StatusCode::MOVED_PERMANENTLY,
+                "/destination2?q=query-string".into()
+            ))
+        );
+
+        assert_eq!(
+            is_redirect(pre_process(
+                &RequestHandlerOpts {
+                    advanced_opts: Some(Advanced {
+                        redirects: Some(get_redirects()),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                },
+                &make_request("example.info", "/source3/whatever?q=query-string")
+            )),
+            Some((
+                StatusCode::MOVED_PERMANENTLY,
+                "/destination3/source3/whatever?q=query-string".into()
+            ))
+        );
+
+        assert_eq!(
+            is_redirect(pre_process(
+                &RequestHandlerOpts {
+                    advanced_opts: Some(Advanced {
+                        redirects: Some(get_redirects()),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                },
+                &make_request("", "/source4/whatever?q=query-string")
+            )),
+            Some((
+                StatusCode::FOUND,
+                "/destination4?p=whatever&q=query-string".into()
             ))
         );
     }

--- a/tests/fixtures/toml/redirects.toml
+++ b/tests/fixtures/toml/redirects.toml
@@ -11,6 +11,12 @@ source = "/{*}"
 destination = "http://localhost:1234/$1"
 kind = 301
 
+# Query string tests
+[[advanced.redirects]]
+source = "/pages/{*}.html"
+destination = "http://localhost:1234/?p=$1"
+kind = 301
+
 # Glob groups 1
 [[advanced.redirects]]
 source = "**/main.{css}"

--- a/tests/redirects.rs
+++ b/tests/redirects.rs
@@ -55,6 +55,32 @@ pub mod tests {
     }
 
     #[tokio::test]
+    async fn redirects_query() {
+        let opts = fixture_settings("toml/redirects.toml");
+        let req_handler_opts = fixture_req_handler_opts(opts.general, opts.advanced);
+        let req_handler = fixture_req_handler(req_handler_opts);
+        let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
+
+        let mut req = Request::new(());
+        *req.uri_mut() = "http://localhost/pages/testing.html?q=query-string"
+            .parse()
+            .unwrap();
+
+        match req_handler.handle(&mut req, remote_addr).await {
+            Ok(res) => {
+                assert_eq!(res.status(), 301);
+                assert_eq!(
+                    res.headers()["location"],
+                    "http://localhost:1234/?p=testing&q=query-string"
+                );
+            }
+            Err(err) => {
+                panic!("unexpected error: {err}")
+            }
+        };
+    }
+
+    #[tokio::test]
     async fn redirects_glob_groups_1() {
         let opts = fixture_settings("toml/redirects.toml");
         let req_handler_opts = fixture_req_handler_opts(opts.general, opts.advanced);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Read the docs/PULL_REQUESTS.md -->

## Description
<!--- Describe your changes but try to be as concise as possible -->

This PR backports a previous v2 PR (https://github.com/static-web-server/static-web-server/pull/703).

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- See how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
