### PR TITLE
Fix: Require authentication for /metrics endpoint when --basic-auth is enabled

### DIFF
--- a/src/handler.rs
+++ b/src/handler.rs
@@ -266,12 +266,6 @@ impl RequestHandler {
                     return result;
                 }
 
-                // Metrics endpoint check
-                #[cfg(feature = "metrics")]
-                if let Some(result) = metrics::pre_process(&self.opts, req) {
-                    return result;
-                }
-
                 // CORS
                 if let Some(result) = cors::pre_process(&self.opts, req) {
                     return result;
@@ -281,6 +275,12 @@ impl RequestHandler {
                 #[cfg(feature = "basic-auth")]
                 if let Some(response) = basic_auth::pre_process(&self.opts, req) {
                     return response;
+                }
+
+                // Metrics endpoint check
+                #[cfg(feature = "metrics")]
+                if let Some(result) = metrics::pre_process(&self.opts, req) {
+                    return result;
                 }
 
                 // Maintenance Mode


### PR DESCRIPTION
## Summary

Move `basic_auth::pre_process` before `metrics::pre_process` in the request pipeline to ensure that `/metrics` is protected when `--basic-auth` is enabled.

## Problem

Previously, the metrics endpoint was processed before authentication, allowing unauthenticated access to Prometheus metrics when both `--basic-auth` and `--metrics` were enabled. This was reported in GHSA-97q6-jph8-rxgm.

## Solution

Reorder the request pipeline so that basic authentication is checked before the metrics endpoint is processed.

## Testing

- Verified that `/metrics` returns 401 without authentication when `--basic-auth` is enabled
- Verified that `/metrics` returns 200 with valid authentication
- Verified that normal paths still require authentication

## Related

- GHSA-97q6-jph8-rxgm