### PR TITLE
Fix metrics endpoint authentication order

### DIFF
--- a/src/handler.rs
+++ b/src/handler.rs
@@ -257,12 +257,6 @@ impl RequestHandler {
                     return result;
                 }
 
-                // Metrics endpoint check
-                #[cfg(feature = "metrics")]
-                if let Some(result) = metrics::pre_process(&self.opts, req) {
-                    return result;
-                }
-
                 // CORS
                 if let Some(result) = cors::pre_process(&self.opts, req) {
                     return result;
@@ -272,6 +266,12 @@ impl RequestHandler {
                 #[cfg(feature = "basic-auth")]
                 if let Some(response) = basic_auth::pre_process(&self.opts, req) {
                     return response;
+                }
+
+                // Metrics endpoint check
+                #[cfg(feature = "metrics")]
+                if let Some(result) = metrics::pre_process(&self.opts, req) {
+                    return result;
                 }
 
                 // Maintenance Mode

--- a/tests/handler.rs
+++ b/tests/handler.rs
@@ -153,4 +153,63 @@ pub mod tests {
             };
         }
     }
+
+    #[cfg(all(feature = "basic-auth", feature = "metrics"))]
+    #[tokio::test]
+    async fn metrics_requires_basic_auth_when_enabled() {
+        let opts = fixture_settings("toml/handler.toml");
+        let mut req_handler_opts = fixture_req_handler_opts(opts.general, opts.advanced);
+        req_handler_opts.basic_auth =
+            "jq:$2y$05$32zazJ1yzhlDHnt26L3MFOgY0HVqPmDUvG0KUx6cjf9RDiUGp/M9q".into();
+        req_handler_opts.metrics_enabled = true;
+        let req_handler = fixture_req_handler(req_handler_opts);
+        let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
+
+        let mut req = Request::default();
+        *req.method_mut() = Method::GET;
+        *req.uri_mut() = "http://localhost/metrics".parse().unwrap();
+
+        match req_handler.handle(&mut req, remote_addr).await {
+            Ok(res) => {
+                assert_eq!(res.status(), 401);
+                assert!(res.headers().get(hyper::header::WWW_AUTHENTICATE).is_some());
+            }
+            Err(err) => {
+                panic!("unexpected error: {err}")
+            }
+        };
+    }
+
+    #[cfg(all(feature = "basic-auth", feature = "metrics"))]
+    #[tokio::test]
+    async fn metrics_allows_valid_basic_auth_when_enabled() {
+        let opts = fixture_settings("toml/handler.toml");
+        let mut req_handler_opts = fixture_req_handler_opts(opts.general, opts.advanced);
+        req_handler_opts.basic_auth =
+            "jq:$2y$05$32zazJ1yzhlDHnt26L3MFOgY0HVqPmDUvG0KUx6cjf9RDiUGp/M9q".into();
+        req_handler_opts.metrics_enabled = true;
+        let req_handler = fixture_req_handler(req_handler_opts);
+        let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
+
+        let mut req = Request::default();
+        *req.method_mut() = Method::GET;
+        *req.uri_mut() = "http://localhost/metrics".parse().unwrap();
+        req.headers_mut().insert(
+            hyper::header::AUTHORIZATION,
+            HeaderValue::from_static("Basic anE6anE="),
+        );
+
+        match req_handler.handle(&mut req, remote_addr).await {
+            Ok(res) => {
+                assert_eq!(res.status(), 200);
+                assert_eq!(
+                    res.headers().get("content-type"),
+                    Some(&HeaderValue::from_static("text/plain; charset=utf-8"))
+                );
+            }
+            Err(err) => {
+                panic!("unexpected error: {err}")
+            }
+        };
+    }
 }


### PR DESCRIPTION
## Summary
- Move the metrics endpoint check (`metrics::pre_process`) to run **after** the basic authentication check in `RequestHandler::handle`, so that `/metrics` is protected by `--basic-auth` when enabled.
- Previously the metrics pre-processing ran before basic auth, allowing unauthenticated access to the metrics endpoint even when basic auth was configured (auth bypass).
- Add two regression tests in `tests/handler.rs` (gated on `basic-auth` + `metrics` features):
  - `metrics_requires_basic_auth_when_enabled`: requests to `/metrics` without credentials return `401` with a `WWW-Authenticate` header.
  - `metrics_allows_valid_basic_auth_when_enabled`: requests with valid basic auth credentials return `200`.

#### Test plan
- [x] `cargo test --features basic-auth,metrics metrics_requires_basic_auth_when_enabled`
- [x] `cargo test --features basic-auth,metrics metrics_allows_valid_basic_auth_when_enabled`
- [ ] CI (full test suite)

Generated with [Devin](https://devin.ai)