### PR TITLE
fix(markdown): prevent path traversal in markdown content negotiation (2.x backport)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,6 +125,7 @@ windows-service = "0.8"
 [dev-dependencies]
 bytes = "1.11.1"
 serde_json = "1.0"
+tempfile = "3"
 
 [build-dependencies]
 shadow-rs = "1.4.0"

--- a/src/markdown.rs
+++ b/src/markdown.rs
@@ -13,7 +13,8 @@ use hyper::{Body, Request, Response};
 use std::path::Path;
 
 use crate::{
-    Error, fs::meta::try_markdown_variant, handler::RequestHandlerOpts, headers_ext::Accept,
+    Error, fs::meta::try_markdown_variant, fs::path::sanitize_path, handler::RequestHandlerOpts,
+    headers_ext::Accept,
 };
 
 /// Pre-process a request to check if a markdown variant URI should be used.
@@ -30,12 +31,8 @@ pub(crate) fn pre_process<T>(req: &Request<T>, base_path: &Path, uri_path: &str)
         return None;
     }
 
-    // Construct the full file path
-    let mut file_path = base_path.to_path_buf();
-    let sanitized_path = uri_path.trim_start_matches('/');
-    if !sanitized_path.is_empty() {
-        file_path.push(sanitized_path);
-    }
+    // Sanitize the URI path before touching the filesystem
+    let file_path = sanitize_path(base_path, uri_path).ok()?;
 
     // Try to find a markdown variant
     let md_path = try_markdown_variant(&file_path)?;
@@ -120,5 +117,31 @@ mod tests {
         let result = pre_process(&req, base_path, "/test");
 
         assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_markdown_pre_process_rejects_traversal() {
+        let tmp_dir = tempfile::tempdir().unwrap();
+        let base_dir = tmp_dir.path().join("base");
+        std::fs::create_dir(&base_dir).unwrap();
+
+        // Create a markdown file outside the base directory
+        let outside_md = tmp_dir.path().join("outside.md");
+        std::fs::write(&outside_md, "outside").unwrap();
+
+        let req = Request::builder()
+            .method("GET")
+            .uri("http://localhost/../outside")
+            .header("Accept", "text/markdown")
+            .body(Body::empty())
+            .unwrap();
+
+        // A request with `../` must not probe files outside the base directory
+        let result = pre_process(&req, &base_dir, "/../outside");
+        assert!(
+            result.is_none(),
+            "markdown pre_process should not resolve paths outside the base directory, got {:?}",
+            result
+        );
     }
 }


### PR DESCRIPTION
## Summary

2.x backport of the markdown content negotiation path traversal fix.

- Reuse `sanitize_path` in `markdown::pre_process` to prevent path traversal via `../` segments when `Accept: text/markdown` is sent.
- Add a regression test that verifies markdown content negotiation does not probe files outside the document root.
- The vulnerable code pushed the raw URI path directly onto `base_path`, causing `std::fs::metadata` to be called on paths outside the configured root before the static file handler sanitized them.

#### Test plan

- [x] `cargo test --lib test_markdown_pre_process_rejects_traversal` passes
- [x] `cargo test --features all --lib` passes (142 tests)
- [x] `cargo clippy --features all -- -D warnings` passes

Generated with [Devin](https://devin.ai)