### PR TITLE
Proper git reference on CI's release-updates workflow for v2

### DIFF
--- a/.github/workflows/release.updates.yml
+++ b/.github/workflows/release.updates.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          ref: master
+          ref: 2.x
 
       - name: Prepare
         shell: bash

--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -23,7 +23,7 @@ fi
 set -ue
 
 # SWS latest version
-version=${SWS_INSTALL_VERSION:-"2.43.0"}
+version=${SWS_INSTALL_VERSION:-"2.44.0"}
 
 # Default directory where SWS will be installed
 install_dir=${SWS_INSTALL_DIR:-"/usr/local/bin"}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Read the docs/PULL_REQUESTS.md -->

## Description
<!--- Describe your changes but try to be as concise as possible -->

This PR fixes an issue that incorrectly referenced the `master` rather than `2.x` for the post-release updates workflow.

PR with the issue: https://github.com/static-web-server/static-web-server/pull/731

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- See how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
