### PR TITLE
Suppress fallback page 404 warnings

### DIFF
--- a/src/error_page.rs
+++ b/src/error_page.rs
@@ -93,10 +93,36 @@ pub fn error_response(
     page404: &Path,
     page50x: &Path,
 ) -> Result<Response<Body>> {
-    tracing::warn!(
-        method = ?method, uri = ?uri, status = status_code.as_u16(),
-        error = status_code.canonical_reason().unwrap_or_default()
-    );
+    error_response_inner(uri, method, status_code, page404, page50x, true)
+}
+
+/// Builds an error response without emitting an operator-facing warning.
+///
+/// This is used when a later pipeline stage will replace the error response.
+pub(crate) fn error_response_without_logging(
+    uri: &Uri,
+    method: &Method,
+    status_code: &StatusCode,
+    page404: &Path,
+    page50x: &Path,
+) -> Result<Response<Body>> {
+    error_response_inner(uri, method, status_code, page404, page50x, false)
+}
+
+fn error_response_inner(
+    uri: &Uri,
+    method: &Method,
+    status_code: &StatusCode,
+    page404: &Path,
+    page50x: &Path,
+    log_warning: bool,
+) -> Result<Response<Body>> {
+    if log_warning {
+        tracing::warn!(
+            method = ?method, uri = ?uri, status = status_code.as_u16(),
+            error = status_code.canonical_reason().unwrap_or_default()
+        );
+    }
 
     // Check for 4xx/50x status codes and handle their corresponding HTML content
     let mut page_content = String::new();

--- a/src/fallback_page.rs
+++ b/src/fallback_page.rs
@@ -35,16 +35,20 @@ pub(crate) fn post_process<T>(
     req: &Request<T>,
     resp: Response<Body>,
 ) -> Result<Response<Body>, Error> {
-    Ok(
-        if req.method().is_get()
-            && resp.status() == StatusCode::NOT_FOUND
-            && !opts.page_fallback.is_empty()
-        {
-            fallback_response(&opts.page_fallback)
-        } else {
-            resp
-        },
-    )
+    Ok(if can_serve(opts, req, resp.status()) {
+        fallback_response(&opts.page_fallback)
+    } else {
+        resp
+    })
+}
+
+/// Returns whether the request and status will be replaced by a fallback page.
+pub(crate) fn can_serve<T>(
+    opts: &RequestHandlerOpts,
+    req: &Request<T>,
+    status: StatusCode,
+) -> bool {
+    req.method().is_get() && status == StatusCode::NOT_FOUND && !opts.page_fallback.is_empty()
 }
 
 /// Checks if a fallback response can be generated, i.e. if it is a `GET` request

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -353,16 +353,32 @@ impl RequestHandler {
                 .await
                 {
                     Ok(result) => (result.resp, Some(result.file_path)),
-                    Err(status) => (
-                        error_page::error_response(
-                            req.uri(),
-                            req.method(),
-                            &status,
-                            &self.opts.page404,
-                            &self.opts.page50x,
-                        )?,
-                        None,
-                    ),
+                    Err(status) => {
+                        #[cfg(feature = "fallback-page")]
+                        let will_serve_fallback = fallback_page::can_serve(&self.opts, req, status);
+                        #[cfg(not(feature = "fallback-page"))]
+                        let will_serve_fallback = false;
+
+                        let resp = if will_serve_fallback {
+                            error_page::error_response_without_logging(
+                                req.uri(),
+                                req.method(),
+                                &status,
+                                &self.opts.page404,
+                                &self.opts.page50x,
+                            )?
+                        } else {
+                            error_page::error_response(
+                                req.uri(),
+                                req.method(),
+                                &status,
+                                &self.opts.page404,
+                                &self.opts.page50x,
+                            )?
+                        };
+
+                        (resp, None)
+                    }
                 };
 
                 // Check for a fallback response

--- a/tests/handler.rs
+++ b/tests/handler.rs
@@ -210,4 +210,51 @@ pub mod tests {
             }
         };
     }
+
+    #[cfg(feature = "fallback-page")]
+    #[tokio::test]
+    async fn page_fallback_does_not_log_not_found_warning() {
+        use std::sync::{
+            Arc,
+            atomic::{AtomicUsize, Ordering},
+        };
+        use tracing::{Event, Level, Subscriber};
+        use tracing_subscriber::{Layer, layer::Context, prelude::*};
+
+        #[derive(Clone, Default)]
+        struct WarningCounter(Arc<AtomicUsize>);
+
+        impl<S> Layer<S> for WarningCounter
+        where
+            S: Subscriber,
+        {
+            fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
+                if *event.metadata().level() == Level::WARN {
+                    self.0.fetch_add(1, Ordering::Relaxed);
+                }
+            }
+        }
+
+        let opts = fixture_settings("toml/handler.toml");
+        let mut req_handler_opts = fixture_req_handler_opts(opts.general, opts.advanced);
+        req_handler_opts.page_fallback = b"fallback".to_vec();
+        let req_handler = fixture_req_handler(req_handler_opts);
+        let remote_addr = Some(REMOTE_ADDR.parse::<SocketAddr>().unwrap());
+
+        let warnings = WarningCounter::default();
+        let subscriber = tracing_subscriber::registry().with(warnings.clone());
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        let mut req = Request::new(());
+        *req.method_mut() = Method::GET;
+        *req.uri_mut() = "http://localhost/missing-route".parse().unwrap();
+
+        let resp = req_handler
+            .handle(&mut req, remote_addr)
+            .await
+            .expect("fallback request should succeed");
+
+        assert_eq!(resp.status(), 200);
+        assert_eq!(warnings.0.load(Ordering::Relaxed), 0);
+    }
 }


### PR DESCRIPTION
## Summary

- detect GET 404 responses that the configured page fallback will replace
- suppress the transient 404 warning only for those responses
- keep warnings unchanged for errors that remain visible to clients
- add an integration regression test around the request handler and tracing output

## Verification

- `cargo +1.88.0 fmt --all -- --check`
- `cargo +1.88.0 test --test handler` (6 passed)
- `cargo +1.88.0 test --test handler --no-default-features` (3 passed)
- `cargo +1.88.0 clippy --features all --tests -- -D warnings` after allowing the current baseline-only `duplicated_attributes`, `unnecessary_literal_unwrap`, and `uninlined_format_args` lints
- full all-feature and no-default-feature suites: all relevant tests passed; the existing Windows symlink test failed identically at the base commit

Closes #603