### PR TITLE
feat(directory_listing): negotiate listing format via Accept header

### DIFF
--- a/src/directory_listing/autoindex/mod.rs
+++ b/src/directory_listing/autoindex/mod.rs
@@ -39,6 +39,7 @@ pub fn auto_index(opts: DirListOpts<'_>) -> Result<Response<Body>, StatusCode> {
                 is_head: opts.method.is_head(),
                 order_code: opts.dir_listing_order,
                 content_format: opts.dir_listing_format,
+                accept: opts.accept,
                 include_hidden: opts.include_hidden,
                 follow_symlinks: opts.follow_symlinks,
                 #[cfg(feature = "directory-listing-download")]

--- a/src/directory_listing/dir.rs
+++ b/src/directory_listing/dir.rs
@@ -16,6 +16,8 @@ use std::path::Path;
 use crate::body::Body;
 use crate::directory_listing::autoindex::{html_auto_index, json_auto_index};
 use crate::directory_listing::file::{FileEntry, FileType};
+use crate::exts::headers::Accept;
+use crate::exts::http::append_vary_accept;
 use crate::{Context, Result};
 
 #[cfg(feature = "directory-listing-download")]
@@ -31,13 +33,16 @@ const PERCENT_ENCODE_SET: &AsciiSet = &NON_ALPHANUMERIC
     .remove(b'~');
 
 /// Directory listing output format for file entries.
-#[derive(Debug, Serialize, Deserialize, Clone, ValueEnum)]
+#[derive(Debug, PartialEq, Serialize, Deserialize, Clone, ValueEnum)]
 #[serde(rename_all = "lowercase")]
 pub enum DirListFmt {
     /// HTML format to display (default).
     Html,
     /// JSON format to display.
     Json,
+    /// Automatically choose the format via the request `Accept` header.
+    /// HTML is used by default when no supported media type is present.
+    Auto,
 }
 
 /// Directory listing options.
@@ -56,6 +61,9 @@ pub struct DirListOpts<'a> {
     pub dir_listing_order: u8,
     /// Directory listing format.
     pub dir_listing_format: &'a DirListFmt,
+    /// Request `Accept` header used to negotiate the listing format when
+    /// `dir_listing_format` is `DirListFmt::Auto`.
+    pub(crate) accept: Option<&'a Accept>,
     #[cfg(feature = "directory-listing-download")]
     /// Directory listing download.
     pub dir_listing_download: &'a [DirDownloadFmt],
@@ -74,6 +82,7 @@ pub(crate) struct DirEntryOpts<'a> {
     pub(crate) is_head: bool,
     pub(crate) order_code: u8,
     pub(crate) content_format: &'a DirListFmt,
+    pub(crate) accept: Option<&'a Accept>,
     pub(crate) include_hidden: bool,
     pub(crate) follow_symlinks: bool,
     #[cfg(feature = "directory-listing-download")]
@@ -219,8 +228,33 @@ pub(crate) fn read_dir_entries(mut opt: DirEntryOpts<'_>) -> Result<Response<Bod
 
     let mut resp = Response::new(crate::body::empty());
 
+    // When `Auto` is set, negotiate the listing format via the request
+    // `Accept` header (q-value order). HTML is the fallback when the header
+    // is absent or lists neither `text/html` nor `application/json`.
+    let content_format = if opt.content_format == &DirListFmt::Auto {
+        let format = opt
+            .accept
+            .and_then(|accept| {
+                accept
+                    .preferred_media_type(&["application/json", "text/html"])
+                    .map(|media_type| {
+                        if media_type == "application/json" {
+                            DirListFmt::Json
+                        } else {
+                            DirListFmt::Html
+                        }
+                    })
+            })
+            .unwrap_or(DirListFmt::Html);
+        // Let caches know the response depends on the `Accept` header.
+        append_vary_accept(&mut resp);
+        format
+    } else {
+        opt.content_format.clone()
+    };
+
     // Handle directory listing content format
-    let content = match opt.content_format {
+    let content = match &content_format {
         DirListFmt::Json => {
             // JSON
             resp.headers_mut()

--- a/src/exts/headers/accept.rs
+++ b/src/exts/headers/accept.rs
@@ -62,6 +62,17 @@ impl Accept {
     pub(crate) fn accepts_markdown(&self) -> bool {
         self.accepts("text/markdown")
     }
+
+    /// Returns the first listed media type among `candidates`, honoring the
+    /// media types q-value order. `None` when none of the candidates is listed.
+    pub(crate) fn preferred_media_type<'a>(&self, candidates: &[&'a str]) -> Option<&'a str> {
+        self.0.iter().find_map(|value| {
+            candidates
+                .iter()
+                .find(|candidate| value.eq_ignore_ascii_case(candidate))
+                .copied()
+        })
+    }
 }
 
 #[cfg(test)]
@@ -101,5 +112,56 @@ mod tests {
         let val = HeaderValue::from_static("text/html, application/json");
         let accept = Accept(val.into());
         assert!(!accept.accepts_markdown());
+    }
+
+    #[test]
+    fn preferred_media_type_json_first() {
+        let val = HeaderValue::from_static("application/json, text/html");
+        let accept = Accept(val.into());
+        assert_eq!(
+            accept.preferred_media_type(&["application/json", "text/html"]),
+            Some("application/json")
+        );
+    }
+
+    #[test]
+    fn preferred_media_type_html_first() {
+        let val = HeaderValue::from_static("text/html, application/json");
+        let accept = Accept(val.into());
+        assert_eq!(
+            accept.preferred_media_type(&["application/json", "text/html"]),
+            Some("text/html")
+        );
+    }
+
+    #[test]
+    fn preferred_media_type_respects_q_values() {
+        // JSON preferred via a higher q-value despite appearing second
+        let val = HeaderValue::from_static("text/html;q=0.8, application/json;q=0.9");
+        let accept = Accept(val.into());
+        assert_eq!(
+            accept.preferred_media_type(&["application/json", "text/html"]),
+            Some("application/json")
+        );
+    }
+
+    #[test]
+    fn preferred_media_type_none_when_absent() {
+        let val = HeaderValue::from_static("text/plain, */*");
+        let accept = Accept(val.into());
+        assert_eq!(
+            accept.preferred_media_type(&["application/json", "text/html"]),
+            None
+        );
+    }
+
+    #[test]
+    fn preferred_media_type_case_insensitive() {
+        let val = HeaderValue::from_static("Application/JSON");
+        let accept = Accept(val.into());
+        assert_eq!(
+            accept.preferred_media_type(&["application/json"]),
+            Some("application/json")
+        );
     }
 }

--- a/src/exts/http.rs
+++ b/src/exts/http.rs
@@ -60,24 +60,37 @@ static VARY_ACCEPT_ENCODING: HeaderValue = HeaderValue::from_static("accept-enco
 /// Append `accept-encoding` to the response's `Vary` header, creating it if absent.
 /// Skips the update if `accept-encoding` is already listed.
 pub(crate) fn append_vary_accept_encoding<B>(resp: &mut Response<B>) {
-    let accept_enc = hyper::header::ACCEPT_ENCODING.as_str();
+    append_vary(resp, "accept-encoding", &VARY_ACCEPT_ENCODING);
+}
+
+/// Append `accept` to the response's `Vary` header, creating it if absent.
+/// Skips the update if `accept` is already listed.
+#[cfg(feature = "directory-listing")]
+pub(crate) fn append_vary_accept<B>(resp: &mut Response<B>) {
+    static VARY_ACCEPT: HeaderValue = HeaderValue::from_static("accept");
+    append_vary(resp, "accept", &VARY_ACCEPT);
+}
+
+/// Append a value to the response's `Vary` header, creating it if absent.
+/// Skips the update if the value is already listed.
+fn append_vary<B>(resp: &mut Response<B>, value: &str, static_value: &HeaderValue) {
     match resp.headers().get(hyper::header::VARY) {
         None => {
             resp.headers_mut()
-                .insert(hyper::header::VARY, VARY_ACCEPT_ENCODING.clone());
+                .insert(hyper::header::VARY, static_value.clone());
         }
         Some(existing) => {
             let s = existing.to_str().unwrap_or_default();
-            if s.contains(accept_enc) {
+            if s.contains(value) {
                 return;
             }
             // Append to existing value
-            let mut new_val = String::with_capacity(s.len() + 2 + accept_enc.len());
+            let mut new_val = String::with_capacity(s.len() + 2 + value.len());
             new_val.push_str(s);
             if !s.is_empty() {
                 new_val.push_str(", ");
             }
-            new_val.push_str(accept_enc);
+            new_val.push_str(value);
             if let Ok(val) = HeaderValue::from_str(&new_val) {
                 resp.headers_mut().insert(hyper::header::VARY, val);
             }

--- a/src/settings/cli.rs
+++ b/src/settings/cli.rs
@@ -441,7 +441,7 @@ pub struct General {
         env = "SERVER_DIRECTORY_LISTING_FORMAT",
         ignore_case(true)
     )]
-    /// Specify a content format for directory listing entries. Formats supported: "html" or "json". Default "html".
+    /// Specify a content format for directory listing entries. Formats supported: "html", "json" or "auto". Default "html".
     pub directory_listing_format: DirListFmt,
 
     #[cfg(feature = "directory-listing-download")]

--- a/src/static_files/listing.rs
+++ b/src/static_files/listing.rs
@@ -15,11 +15,13 @@
 
 #![cfg(feature = "directory-listing")]
 
+use headers::HeaderMapExt;
 use hyper::{Response, StatusCode};
 use std::path::Path;
 
 use crate::body::Body;
 use crate::directory_listing::{self, DirListOpts};
+use crate::exts::headers::Accept;
 
 #[cfg(feature = "directory-listing-download")]
 use crate::directory_listing::download::{DOWNLOAD_PARAM_KEY, DirDownloadOpts, archive_reply};
@@ -50,6 +52,7 @@ pub(super) fn try_listing(
         filepath: file_path,
         dir_listing_order: opts.dir_listing_order,
         dir_listing_format: opts.dir_listing_format,
+        accept: opts.headers.typed_get::<Accept>().as_ref(),
         include_hidden: opts.include_hidden,
         follow_symlinks: opts.follow_symlinks,
         #[cfg(feature = "directory-listing-download")]

--- a/tests/dir_listing.rs
+++ b/tests/dir_listing.rs
@@ -639,4 +639,109 @@ mod tests {
         let _ = fs::remove_file(&evil);
         let _ = fs::remove_dir(&tmp);
     }
+
+    #[tokio::test]
+    async fn dir_listing_auto_format_via_accept_json() {
+        let mut headers = HeaderMap::new();
+        headers.insert("accept", "application/json".parse().unwrap());
+
+        let result = static_files::handle(&HandleOpts {
+            method: &Method::GET,
+            headers: &headers,
+            base_path: &root_dir("tests/fixtures/public"),
+            uri_path: "/",
+            uri_query: None,
+            #[cfg(feature = "mem-cache")]
+            memory_cache: None,
+            dir_listing: true,
+            dir_listing_order: 6,
+            dir_listing_format: &DirListFmt::Auto,
+            redirect_trailing_slash: true,
+            compression_static: false,
+            etag: true,
+            include_hidden: true,
+            follow_symlinks: true,
+            index_files: &[],
+            #[cfg(feature = "directory-listing-download")]
+            dir_listing_download: &[],
+        })
+        .await
+        .expect("handle should succeed for GET on a readable directory");
+
+        let res = result.resp;
+        assert_eq!(res.status(), 200);
+        assert_eq!(res.headers()["content-type"], "application/json");
+    }
+
+    #[tokio::test]
+    async fn dir_listing_auto_format_via_accept_html() {
+        let mut headers = HeaderMap::new();
+        headers.insert("accept", "text/html".parse().unwrap());
+
+        let result = static_files::handle(&HandleOpts {
+            method: &Method::GET,
+            headers: &headers,
+            base_path: &root_dir("tests/fixtures/public"),
+            uri_path: "/",
+            uri_query: None,
+            #[cfg(feature = "mem-cache")]
+            memory_cache: None,
+            dir_listing: true,
+            dir_listing_order: 6,
+            dir_listing_format: &DirListFmt::Auto,
+            redirect_trailing_slash: true,
+            compression_static: false,
+            etag: true,
+            include_hidden: true,
+            follow_symlinks: true,
+            index_files: &[],
+            #[cfg(feature = "directory-listing-download")]
+            dir_listing_download: &[],
+        })
+        .await
+        .expect("handle should succeed for GET on a readable directory");
+
+        let res = result.resp;
+        assert_eq!(res.status(), 200);
+        assert_eq!(res.headers()["content-type"], "text/html; charset=utf-8");
+    }
+
+    #[tokio::test]
+    async fn dir_listing_auto_format_defaults_to_html() {
+        // No `Accept` header and an unrelated media type must both fall back
+        // to the HTML listing.
+        for accept in [None, Some("text/plain")] {
+            let mut headers = HeaderMap::new();
+            if let Some(value) = accept {
+                headers.insert("accept", value.parse().unwrap());
+            }
+
+            let result = static_files::handle(&HandleOpts {
+                method: &Method::GET,
+                headers: &headers,
+                base_path: &root_dir("tests/fixtures/public"),
+                uri_path: "/",
+                uri_query: None,
+                #[cfg(feature = "mem-cache")]
+                memory_cache: None,
+                dir_listing: true,
+                dir_listing_order: 6,
+                dir_listing_format: &DirListFmt::Auto,
+                redirect_trailing_slash: true,
+                compression_static: false,
+                etag: true,
+                include_hidden: true,
+                follow_symlinks: true,
+                index_files: &[],
+                #[cfg(feature = "directory-listing-download")]
+                dir_listing_download: &[],
+            })
+            .await
+            .expect("handle should succeed for GET on a readable directory");
+
+            let res = result.resp;
+            assert_eq!(res.status(), 200);
+            assert_eq!(res.headers()["content-type"], "text/html; charset=utf-8");
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Adds a new `auto` value for `--directory-listing-format` (and `DirListFmt::Auto`) that chooses the listing format per request based on the `Accept` header, exactly as suggested in #366:

- `application/json` listed first (q-value order) → JSON listing
- `text/html` listed first → HTML listing
- header absent or neither listed → HTML (fallback)

Existing `html`/`json` values keep working unchanged; the default stays `html`, so current configs are unaffected.

## Implementation notes

- Reuses the existing `Accept`/`QualityValue` types in `src/exts/headers` (the same machinery already used for Accept-Encoding and markdown negotiation) — no new dependencies.
- `Accept::preferred_media_type()` returns the highest-q candidate media type; the mapping to `DirListFmt` lives in `directory_listing/dir.rs`.
- When `Auto` negotiates, the response carries `Vary: Accept` (append-style helper in `exts/http.rs`, same shape as the existing `append_vary_accept_encoding`) so caches don't serve a stale format.

## Verification

- `cargo check --features all` ✅
- `cargo check --no-default-features` ✅ (no feature-leak)
- `cargo clippy --features all -- -D warnings` ✅
- `cargo fmt --all -- --check` ✅
- `cargo test --features all` — full suite green (278 lib tests + integration tests, including 3 new Auto-format integration tests and 5 new unit tests)

Closes #366