### PR TITLE
Round q-values instead of truncating in `headers` module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@
 **/*empty*
 **/*.json
 **/*.csv
+**/.DS_Store
 /benches/Cargo.lock
 release
 .vscode
@@ -31,4 +32,4 @@ docker/devel/static-web-server
 !/docs
 !/tests/fixtures/**/*
 !benchmark/sws_benchmarks*.csv
-**/.DS_Store
+!proptest-regressions/**/*.txt

--- a/proptest-regressions/exts/headers/quality_value.txt
+++ b/proptest-regressions/exts/headers/quality_value.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 1c5e04c534524c466d6bb98bc5f3767cc1379dedbd0c9a138f202e8960bb77d0

--- a/src/exts/headers/quality_value.rs
+++ b/src/exts/headers/quality_value.rs
@@ -46,7 +46,10 @@ impl<'a> TryFrom<&'a str> for QualityMeta<'a> {
                 if let Some(value) = part.strip_prefix("q=")
                     && let Ok(parsed) = value.trim().parse::<f32>()
                 {
-                    quality = (parsed * 1000_f32) as u16;
+                    // Round (not truncate) so three-decimal q-values survive the
+                    // f32 round-trip (e.g. "0.502" parses just below 0.502 and
+                    // would truncate to 501), and clamp to the RFC 7231 maximum.
+                    quality = ((parsed * 1000_f32).round() as u16).min(1000);
                 }
             }
         }
@@ -239,6 +242,33 @@ mod tests {
         assert_eq!(values.next(), Some("deflate"));
         assert_eq!(values.next(), Some("br"));
         assert_eq!(values.next(), Some("*"));
+        assert_eq!(values.next(), None);
+    }
+
+    #[test]
+    fn three_decimal_qualities_are_not_truncated() {
+        // Regression test: "0.502" parses as an f32 slightly below 0.502;
+        // truncating `parsed * 1000.0` yielded 501, colliding with q=0.501
+        // and making the ordering of the two entries unstable.
+        let val = HeaderValue::from_static("a;q=0.501, b;q=0.502");
+        let qual = QualityValue::from(val);
+
+        let mut values = qual.iter();
+        assert_eq!(values.next(), Some("b"));
+        assert_eq!(values.next(), Some("a"));
+        assert_eq!(values.next(), None);
+    }
+
+    #[test]
+    fn quality_above_one_is_clamped() {
+        // RFC 7231: qvalue is at most 1. "q=5" must not outrank "q=1".
+        let val = HeaderValue::from_static("gzip;q=1, br;q=5");
+        let qual = QualityValue::from(val);
+
+        let mut values = qual.iter();
+        // Both clamp to 1000; tie broken by ContentCoding priority (br > gzip).
+        assert_eq!(values.next(), Some("br"));
+        assert_eq!(values.next(), Some("gzip"));
         assert_eq!(values.next(), None);
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Read the docs/PULL_REQUESTS.md -->

## Description
<!--- Describe your changes but try to be as concise as possible -->

This PR fixes an issue where the `Accept-Encoding` _q-value_ parser truncated instead of rounding, so `q=0.502` collided with `q=0.501` and the two encodings tied, leaving their order undefined. The parser now rounds and clamps to the RFC 7231 maximum of 1.

**Error logs**

```
test exts::headers::quality_value::tests::prop_iter_orders_q_values_descending ... FAILED

failures:
---- exts::headers::quality_value::tests::prop_iter_orders_q_values_descending stdout ----
proptest: Saving this and future failures in /project/proptest-regressions/exts/headers/quality_value.txt
proptest: If this test was run on a CI system, you may wish to add the following line to your copy of the file. (You may need to create it.)
cc 1c5e04c534524c466d6bb98bc5f3767cc1379dedbd0c9a138f202e8960bb77d0

thread 'exts::headers::quality_value::tests::prop_iter_orders_q_values_descending' (784) panicked at src/exts/headers/quality_value.rs:258:5:
Test failed: expected `a` (q=501) after `b` (q=502) in ["a", "b"] at src/exts/headers/quality_value.rs:296.
minimal failing input: a = "a", b = "b", qa = 501, qb = 502
	successes: 240
	local rejects: 0
	global rejects: 0

note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

failures:
    exts::headers::quality_value::tests::prop_iter_orders_q_values_descending

test result: FAILED. 200 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 18.61s

error: test failed, to rerun pass `--lib`
+ rustup component list --toolchain stable-x86_64-unknown-linux-gnu
```

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- See how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
