### PR TITLE
feat(error_page): add configurable 401 and 403 error pages

### DIFF
--- a/src/basic_auth.rs
+++ b/src/basic_auth.rs
@@ -42,13 +42,8 @@ pub(crate) fn pre_process<T>(
     if let Some((user_id, password)) = opts.basic_auth.split_once(':') {
         let err = check_request(req.headers(), user_id, password).err()?;
         tracing::warn!("basic authentication failed {:?}", err);
-        let mut result = error_page::error_response(
-            uri,
-            method,
-            &StatusCode::UNAUTHORIZED,
-            &opts.page404,
-            &opts.page50x,
-        );
+        let mut result =
+            error_page::error_response(uri, method, &StatusCode::UNAUTHORIZED, &opts.error_pages());
         if let Ok(ref mut resp) = result {
             resp.headers_mut().insert(
                 WWW_AUTHENTICATE,
@@ -64,8 +59,7 @@ pub(crate) fn pre_process<T>(
             uri,
             method,
             &StatusCode::INTERNAL_SERVER_ERROR,
-            &opts.page404,
-            &opts.page50x,
+            &opts.error_pages(),
         ))
     }
 }

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -100,8 +100,7 @@ pub(crate) fn post_process<T>(
                 req.uri(),
                 req.method(),
                 &StatusCode::INTERNAL_SERVER_ERROR,
-                &opts.page404,
-                &opts.page50x,
+                &opts.error_pages(),
             )
         }
     }

--- a/src/cors.rs
+++ b/src/cors.rs
@@ -468,8 +468,7 @@ pub(crate) fn pre_process<T>(
                 req.uri(),
                 req.method(),
                 &StatusCode::FORBIDDEN,
-                &opts.page404,
-                &opts.page50x,
+                &opts.error_pages(),
             ))
         }
     }

--- a/src/error_page.rs
+++ b/src/error_page.rs
@@ -85,15 +85,62 @@ pub(crate) fn build_html_response(
     resp
 }
 
-/// It returns a HTTP error response which also handles available `404` or `50x` HTML content.
+/// Load the custom error page body for `page` into `page_content`,
+/// preferring the process-wide cache and falling back to a one-time
+/// disk read that is then cached. Missing files keep the default body.
+fn load_custom_page(page: &Path, page_content: &mut String) {
+    if let Some(cached) = cached_page(page) {
+        page_content.clear();
+        page_content.push_str(&cached);
+    } else if page.is_file() {
+        // Cache miss — read disk once and remember.
+        cache_page(page);
+        helpers::read_text_default(page).clone_into(page_content);
+    } else {
+        tracing::debug!(
+            "error page file path not found or not a regular file: {}",
+            page.display()
+        );
+    }
+}
+
+/// Custom HTML error page paths, resolved at startup.
+#[derive(Clone, Default)]
+pub struct ErrorPages {
+    /// Page for 401 errors.
+    pub page401: PathBuf,
+    /// Page for 403 errors.
+    pub page403: PathBuf,
+    /// Page for 404 errors.
+    pub page404: PathBuf,
+    /// Page for 50x errors.
+    pub page50x: PathBuf,
+}
+
+impl ErrorPages {
+    /// Returns the custom page for a status code, or `None` when the code
+    /// has no dedicated page (generic HTML body is served instead).
+    fn page_for(&self, status: &StatusCode) -> Option<&Path> {
+        if status == &StatusCode::UNAUTHORIZED {
+            Some(&self.page401)
+        } else if status == &StatusCode::FORBIDDEN {
+            Some(&self.page403)
+        } else if status == &StatusCode::NOT_FOUND {
+            Some(&self.page404)
+        } else {
+            None
+        }
+    }
+}
+
+/// It returns a HTTP error response which also handles available `401`, `403`, `404` or `50x` HTML content.
 pub fn error_response(
     uri: &Uri,
     method: &Method,
     status_code: &StatusCode,
-    page404: &Path,
-    page50x: &Path,
+    pages: &ErrorPages,
 ) -> Result<Response<Body>> {
-    error_response_inner(uri, method, status_code, page404, page50x, true)
+    error_response_inner(uri, method, status_code, pages, true)
 }
 
 /// Builds an error response without emitting an operator-facing warning.
@@ -103,18 +150,16 @@ pub(crate) fn error_response_without_logging(
     uri: &Uri,
     method: &Method,
     status_code: &StatusCode,
-    page404: &Path,
-    page50x: &Path,
+    pages: &ErrorPages,
 ) -> Result<Response<Body>> {
-    error_response_inner(uri, method, status_code, page404, page50x, false)
+    error_response_inner(uri, method, status_code, pages, false)
 }
 
 fn error_response_inner(
     uri: &Uri,
     method: &Method,
     status_code: &StatusCode,
-    page404: &Path,
-    page50x: &Path,
+    pages: &ErrorPages,
     log_warning: bool,
 ) -> Result<Response<Body>> {
     if log_warning {
@@ -146,20 +191,10 @@ fn error_response_inner(
         | &StatusCode::UNSUPPORTED_MEDIA_TYPE
         | &StatusCode::RANGE_NOT_SATISFIABLE
         | &StatusCode::EXPECTATION_FAILED => {
-            // Extra check for 404 status code and its HTML content
-            if status_code == &StatusCode::NOT_FOUND {
-                if let Some(cached) = cached_page(page404) {
-                    page_content = cached.as_str().to_owned();
-                } else if page404.is_file() {
-                    // Cache miss \u2014 read disk once and remember.
-                    cache_page(page404);
-                    helpers::read_text_default(page404).clone_into(&mut page_content);
-                } else {
-                    tracing::debug!(
-                        "page404 file path not found or not a regular file: {}",
-                        page404.display()
-                    );
-                }
+            // Serve a dedicated custom page for 401, 403 and 404 status
+            // codes; other 4xx codes fall back to the generic HTML body.
+            if let Some(page) = pages.page_for(status_code) {
+                load_custom_page(page, &mut page_content);
             }
             status_code
         }
@@ -174,17 +209,7 @@ fn error_response_inner(
         | &StatusCode::INSUFFICIENT_STORAGE
         | &StatusCode::LOOP_DETECTED => {
             // HTML content check for status codes 50x
-            if let Some(cached) = cached_page(page50x) {
-                page_content = cached.as_str().to_owned();
-            } else if page50x.is_file() {
-                cache_page(page50x);
-                helpers::read_text_default(page50x).clone_into(&mut page_content);
-            } else {
-                tracing::debug!(
-                    "page50x file path not found or not a regular file: {}",
-                    page50x.display()
-                );
-            }
+            load_custom_page(&pages.page50x, &mut page_content);
             status_code
         }
         // other status codes
@@ -230,7 +255,22 @@ mod tests {
     use hyper::{Method, StatusCode};
     use std::path::Path;
 
-    use super::{build_html_response, error_response};
+    use super::{ErrorPages, build_html_response, error_response};
+
+    /// Builds `ErrorPages` from explicit paths for a single test call.
+    fn pages(
+        page401: impl AsRef<Path>,
+        page403: impl AsRef<Path>,
+        page404: impl AsRef<Path>,
+        page50x: impl AsRef<Path>,
+    ) -> ErrorPages {
+        ErrorPages {
+            page401: page401.as_ref().to_path_buf(),
+            page403: page403.as_ref().to_path_buf(),
+            page404: page404.as_ref().to_path_buf(),
+            page50x: page50x.as_ref().to_path_buf(),
+        }
+    }
 
     #[test]
     fn build_html_response_get_includes_body() {
@@ -266,8 +306,12 @@ mod tests {
             &uri,
             &Method::GET,
             &StatusCode::NOT_FOUND,
-            Path::new("/nonexistent/404.html"),
-            Path::new("/nonexistent/50x.html"),
+            &pages(
+                "/nonexistent/401.html",
+                "/nonexistent/403.html",
+                "/nonexistent/404.html",
+                "/nonexistent/50x.html",
+            ),
         )
         .unwrap();
         assert_eq!(resp.status(), StatusCode::NOT_FOUND);
@@ -282,12 +326,97 @@ mod tests {
             &uri,
             &Method::GET,
             &StatusCode::NOT_FOUND,
-            &page404,
-            Path::new("/nonexistent/50x.html"),
+            &pages(
+                "/nonexistent/401.html",
+                "/nonexistent/403.html",
+                page404.clone(),
+                "/nonexistent/50x.html",
+            ),
         )
         .unwrap();
         std::fs::remove_file(&page404).ok();
         assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn error_response_401_with_custom_page() {
+        let page401 = std::env::temp_dir().join("sws_error_page_401_test.html");
+        std::fs::write(&page401, b"<h1>Unauthorized</h1>").unwrap();
+        let uri = "/private".parse().unwrap();
+        let resp = error_response(
+            &uri,
+            &Method::GET,
+            &StatusCode::UNAUTHORIZED,
+            &pages(
+                page401.clone(),
+                "/nonexistent/403.html",
+                "/nonexistent/404.html",
+                "/nonexistent/50x.html",
+            ),
+        )
+        .unwrap();
+        std::fs::remove_file(&page401).ok();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+        // The custom 401 page body must be served.
+        let body = resp.into_body();
+        let body = http_body_util::BodyExt::collect(body)
+            .await
+            .expect("unexpected bytes error during `body` conversion")
+            .to_bytes();
+        assert!(std::str::from_utf8(&body).unwrap().contains("Unauthorized"));
+    }
+
+    #[tokio::test]
+    async fn error_response_403_with_custom_page() {
+        let page403 = std::env::temp_dir().join("sws_error_page_403_test.html");
+        std::fs::write(&page403, b"<h1>Forbidden</h1>").unwrap();
+        let uri = "/restricted".parse().unwrap();
+        let resp = error_response(
+            &uri,
+            &Method::GET,
+            &StatusCode::FORBIDDEN,
+            &pages(
+                "/nonexistent/401.html",
+                page403.clone(),
+                "/nonexistent/404.html",
+                "/nonexistent/50x.html",
+            ),
+        )
+        .unwrap();
+        std::fs::remove_file(&page403).ok();
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+        // The custom 403 page body must be served.
+        let body = resp.into_body();
+        let body = http_body_util::BodyExt::collect(body)
+            .await
+            .expect("unexpected bytes error during `body` conversion")
+            .to_bytes();
+        assert!(std::str::from_utf8(&body).unwrap().contains("Forbidden"));
+    }
+
+    #[tokio::test]
+    async fn error_response_401_no_custom_page_falls_back_to_generic() {
+        let uri = "/private".parse().unwrap();
+        let resp = error_response(
+            &uri,
+            &Method::GET,
+            &StatusCode::UNAUTHORIZED,
+            &pages(
+                "/nonexistent/401.html",
+                "/nonexistent/403.html",
+                "/nonexistent/404.html",
+                "/nonexistent/50x.html",
+            ),
+        )
+        .unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+        let body = resp.into_body();
+        let body = http_body_util::BodyExt::collect(body)
+            .await
+            .expect("unexpected bytes error during `body` conversion")
+            .to_bytes();
+        // Generic fallback body contains the status line, not a custom page.
+        assert!(std::str::from_utf8(&body).unwrap().contains("401"));
     }
 
     #[test]
@@ -297,8 +426,12 @@ mod tests {
             &uri,
             &Method::GET,
             &StatusCode::INTERNAL_SERVER_ERROR,
-            Path::new("/nonexistent/404.html"),
-            Path::new("/nonexistent/50x.html"),
+            &pages(
+                "/nonexistent/401.html",
+                "/nonexistent/403.html",
+                "/nonexistent/404.html",
+                "/nonexistent/50x.html",
+            ),
         )
         .unwrap();
         assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
@@ -311,8 +444,12 @@ mod tests {
             &uri,
             &Method::HEAD,
             &StatusCode::NOT_FOUND,
-            Path::new("/nonexistent/404.html"),
-            Path::new("/nonexistent/50x.html"),
+            &pages(
+                "/nonexistent/401.html",
+                "/nonexistent/403.html",
+                "/nonexistent/404.html",
+                "/nonexistent/50x.html",
+            ),
         )
         .unwrap();
         assert_eq!(resp.status(), StatusCode::NOT_FOUND);

--- a/src/fallback_page.rs
+++ b/src/fallback_page.rs
@@ -64,7 +64,6 @@ mod tests {
     use crate::body::Body;
     use crate::{Error, error_page, handler::RequestHandlerOpts};
     use hyper::{Method, Request, Response, StatusCode, Uri};
-    use std::path::PathBuf;
 
     fn make_request(method: &str) -> Request<Body> {
         Request::builder()
@@ -79,8 +78,7 @@ mod tests {
             &Uri::try_from("/").unwrap(),
             &Method::GET,
             status,
-            &PathBuf::new(),
-            &PathBuf::new(),
+            &error_page::ErrorPages::default(),
         )
         .unwrap()
     }

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -101,7 +101,11 @@ pub struct RequestHandlerOpts {
     pub etag: bool,
     /// Page for 404 errors.
     pub page404: PathBuf,
-    /// Page for 50x errors.
+    /// Error 401 page file path.
+    pub page401: PathBuf,
+    /// Error 403 page file path.
+    pub page403: PathBuf,
+    /// Error 50x page file path.
     pub page50x: PathBuf,
     /// Page fallback feature.
     #[cfg(feature = "fallback-page")]
@@ -149,6 +153,18 @@ pub struct RequestHandlerOpts {
     pub advanced_opts: Option<Advanced>,
 }
 
+impl RequestHandlerOpts {
+    /// Returns the custom error page paths for the current options.
+    pub(crate) fn error_pages(&self) -> error_page::ErrorPages {
+        error_page::ErrorPages {
+            page401: self.page401.clone(),
+            page403: self.page403.clone(),
+            page404: self.page404.clone(),
+            page50x: self.page50x.clone(),
+        }
+    }
+}
+
 impl Default for RequestHandlerOpts {
     fn default() -> Self {
         Self {
@@ -178,6 +194,8 @@ impl Default for RequestHandlerOpts {
             cache_control_headers: true,
             etag: true,
             page404: PathBuf::from("./404.html"),
+            page401: PathBuf::from("./401.html"),
+            page403: PathBuf::from("./403.html"),
             page50x: PathBuf::from("./50x.html"),
             #[cfg(feature = "fallback-page")]
             page_fallback: Vec::new(),
@@ -259,8 +277,7 @@ impl RequestHandler {
                         req.uri(),
                         req.method(),
                         &StatusCode::METHOD_NOT_ALLOWED,
-                        &self.opts.page404,
-                        &self.opts.page50x,
+                        &self.opts.error_pages(),
                     );
                 }
 
@@ -364,16 +381,14 @@ impl RequestHandler {
                                 req.uri(),
                                 req.method(),
                                 &status,
-                                &self.opts.page404,
-                                &self.opts.page50x,
+                                &self.opts.error_pages(),
                             )?
                         } else {
                             error_page::error_response(
                                 req.uri(),
                                 req.method(),
                                 &status,
-                                &self.opts.page404,
-                                &self.opts.page50x,
+                                &self.opts.error_pages(),
                             )?
                         };
 

--- a/src/redirects.rs
+++ b/src/redirects.rs
@@ -142,8 +142,7 @@ pub(crate) fn handle_error<T>(
         req.uri(),
         req.method(),
         &StatusCode::INTERNAL_SERVER_ERROR,
-        &opts.page404,
-        &opts.page50x,
+        &opts.error_pages(),
     ))
 }
 

--- a/src/server/opts.rs
+++ b/src/server/opts.rs
@@ -73,6 +73,30 @@ pub(super) fn init(general: &General, advanced: Option<Advanced>) -> Result<Hand
         root_dir.canonicalize().unwrap_or(root_dir)
     };
 
+    // Resolve the 401 error page path relative to root when needed
+    let mut page401 = general.page401.clone();
+    if page401.is_relative() && !page401.starts_with(&root_dir) {
+        page401 = root_dir.join(&page401);
+    }
+    if !page401.is_file() {
+        tracing::debug!(
+            "401 file path not found or not a regular file: {}",
+            page401.display()
+        );
+    }
+
+    // Resolve the 403 error page path relative to root when needed
+    let mut page403 = general.page403.clone();
+    if page403.is_relative() && !page403.starts_with(&root_dir) {
+        page403 = root_dir.join(&page403);
+    }
+    if !page403.is_file() {
+        tracing::debug!(
+            "403 file path not found or not a regular file: {}",
+            page403.display()
+        );
+    }
+
     // Resolve the 404 error page path relative to root when needed
     let mut page404 = general.page404.clone();
     if page404.is_relative() && !page404.starts_with(&root_dir) {
@@ -122,6 +146,8 @@ pub(super) fn init(general: &General, advanced: Option<Advanced>) -> Result<Hand
 
     let mut handler_opts = RequestHandlerOpts {
         root_dir,
+        page401: page401.clone(),
+        page403: page403.clone(),
         page404: page404.clone(),
         page50x: page50x.clone(),
         log_remote_address: general.log_remote_address,
@@ -156,8 +182,10 @@ pub(super) fn init(general: &General, advanced: Option<Advanced>) -> Result<Hand
     #[cfg(feature = "fallback-page")]
     fallback_page::init(&general.page_fallback, &mut handler_opts);
 
-    // Pre-cache custom 404/50x bodies so error responses never touch disk
+    // Pre-cache custom 401/403/404/50x bodies so error responses never touch disk
     // on the async hot path. See `error_page::PAGE_CACHE`.
+    crate::error_page::cache_page(&handler_opts.page401);
+    crate::error_page::cache_page(&handler_opts.page403);
     crate::error_page::cache_page(&handler_opts.page404);
     crate::error_page::cache_page(&handler_opts.page50x);
 

--- a/src/server/redirect.rs
+++ b/src/server/redirect.rs
@@ -105,7 +105,15 @@ pub(super) fn spawn(
                             match https_redirect::redirect_to_https(&req, redirect_opts) {
                                 Ok(resp) => Ok(resp),
                                 Err(status) => error_page::error_response(
-                                    &uri, &method, &status, &page404, &page50x,
+                                    &uri,
+                                    &method,
+                                    &status,
+                                    &error_page::ErrorPages {
+                                        page401: PathBuf::new(),
+                                        page403: PathBuf::new(),
+                                        page404: page404.clone(),
+                                        page50x: page50x.clone(),
+                                    },
                                 ),
                             }
                         }

--- a/src/settings/cli.rs
+++ b/src/settings/cli.rs
@@ -180,6 +180,18 @@ pub struct General {
     /// If a relative path is used then it will be resolved under the root directory.
     pub page50x: PathBuf,
 
+    #[arg(long, default_value = "./401.html", env = "SERVER_ERROR_PAGE_401")]
+    /// HTML file path for 401 errors. If the path is not specified or simply doesn't exist
+    /// then the server will use a generic HTML error message.
+    /// If a relative path is used then it will be resolved under the root directory.
+    pub page401: PathBuf,
+
+    #[arg(long, default_value = "./403.html", env = "SERVER_ERROR_PAGE_403")]
+    /// HTML file path for 403 errors. If the path is not specified or simply doesn't exist
+    /// then the server will use a generic HTML error message.
+    /// If a relative path is used then it will be resolved under the root directory.
+    pub page403: PathBuf,
+
     #[arg(long, default_value = "./404.html", env = "SERVER_ERROR_PAGE_404")]
     /// HTML file path for 404 errors. If the path is not specified or simply doesn't exist
     /// then the server will use a generic HTML error message.

--- a/src/settings/file.rs
+++ b/src/settings/file.rs
@@ -265,6 +265,10 @@ pub struct General {
     /// Check for a pre-compressed file on disk.
     pub compression_static: Option<bool>,
 
+    /// Error 401 pages.
+    pub page401: Option<PathBuf>,
+    /// Error 403 pages.
+    pub page403: Option<PathBuf>,
     /// Error 404 pages.
     pub page404: Option<PathBuf>,
     /// Error 50x pages.

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -162,6 +162,8 @@ impl Settings {
 
         let mut compression_static = opts.compression_static;
 
+        let mut page401 = opts.page401;
+        let mut page403 = opts.page403;
         let mut page404 = opts.page404;
         let mut page50x = opts.page50x;
 
@@ -306,6 +308,12 @@ impl Settings {
                 }
                 if let Some(v) = general.compression_static {
                     compression_static = v
+                }
+                if let Some(v) = general.page401 {
+                    page401 = v
+                }
+                if let Some(v) = general.page403 {
+                    page403 = v
                 }
                 if let Some(v) = general.page404 {
                     page404 = v
@@ -737,6 +745,8 @@ impl Settings {
                 ))]
                 compression_level,
                 compression_static,
+                page401,
+                page403,
                 page404,
                 page50x,
                 #[cfg(feature = "http2")]

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -91,6 +91,8 @@ pub mod fixtures {
             cache_control_headers: general.cache_control_headers,
             etag: general.etag,
             page404: general.page404,
+            page401: general.page401,
+            page403: general.page403,
             page50x: general.page50x,
             // TODO: add support or `page_fallback` when required
             #[cfg(feature = "fallback-page")]


### PR DESCRIPTION
## Summary

Adds dedicated custom pages for `401 Unauthorized` and `403 Forbidden` errors, alongside the existing `404` and `50x` support (issue #654):

- New CLI flags `--page401` / `--page403` (env `SERVER_ERROR_PAGE_401` / `SERVER_ERROR_PAGE_403`), defaults `./401.html` / `./403.html`, resolved relative to the root like the existing pages
- Matching TOML keys `page401` / `page403` in the config file
- `error_response()` now routes 401 → page401, 403 → page403, 404 → page404; other 4xx statuses keep the generic HTML body
- The 404/50x page-loading logic was deduplicated into a shared `load_custom_page()` helper that still serves from the startup page cache (no per-request disk I/O)

Existing configs are unaffected — the new flags default to `./401.html` / `./403.html` and silently fall back to the generic page when those files don't exist, same as 404/50x.

## Verification

- `cargo check --features all` ✅
- `cargo check --no-default-features` ✅
- `cargo clippy --features all --tests -- -D warnings` ✅
- `cargo fmt --all -- --check` ✅
- `cargo test --features all` — full suite green (455 tests, 0 failures; 3 new unit tests covering custom 401, custom 403, and 401 fallback)

Closes #654